### PR TITLE
feat: update landing page with splash template and all doc repos

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,12 +1,102 @@
 ---
 title: F5 Distributed Cloud
+template: splash
+hero:
+  tagline: Sales engineering documentation and demo guides for F5 Distributed Cloud solutions.
+  actions:
+    - text: Get Started
+      link: https://f5xc-salesdemos.github.io/docs-builder/
+      icon: right-arrow
+      variant: primary
+    - text: View on GitHub
+      link: https://github.com/f5xc-salesdemos
+      icon: external
+      variant: minimal
 ---
 
 import { LinkCard, CardGrid } from '@astrojs/starlight/components';
 
-Welcome to the F5 Distributed Cloud documentation hub.
+## Security Solutions
 
-## Documentation Sites
+<CardGrid>
+  <LinkCard
+    title="WAF"
+    description="Web application firewall configuration and policies."
+    href="https://f5xc-salesdemos.github.io/waf/"
+  />
+  <LinkCard
+    title="API"
+    description="API discovery, protection, and security policies."
+    href="https://f5xc-salesdemos.github.io/api/"
+  />
+  <LinkCard
+    title="Bot Advanced"
+    description="Advanced bot defense with behavioral analysis."
+    href="https://f5xc-salesdemos.github.io/bot-advanced/"
+  />
+  <LinkCard
+    title="Bot Standard"
+    description="Standard bot defense with signature-based detection."
+    href="https://f5xc-salesdemos.github.io/bot-standard/"
+  />
+  <LinkCard
+    title="CSD"
+    description="Client-side defense for browser-based threats."
+    href="https://f5xc-salesdemos.github.io/csd/"
+  />
+  <LinkCard
+    title="DDoS"
+    description="Distributed denial-of-service protection."
+    href="https://f5xc-salesdemos.github.io/ddos/"
+  />
+  <LinkCard
+    title="WAS"
+    description="Web application scanning and vulnerability assessment."
+    href="https://f5xc-salesdemos.github.io/was/"
+  />
+</CardGrid>
+
+## Networking &amp; Performance
+
+<CardGrid>
+  <LinkCard
+    title="MCN"
+    description="Multi-cloud networking and site connectivity."
+    href="https://f5xc-salesdemos.github.io/mcn/"
+  />
+  <LinkCard
+    title="CDN"
+    description="Content delivery network and edge caching."
+    href="https://f5xc-salesdemos.github.io/cdn/"
+  />
+  <LinkCard
+    title="DNS"
+    description="DNS management, zones, and load balancing."
+    href="https://f5xc-salesdemos.github.io/dns/"
+  />
+  <LinkCard
+    title="NGINX"
+    description="NGINX integration and configuration management."
+    href="https://f5xc-salesdemos.github.io/nginx/"
+  />
+</CardGrid>
+
+## Operations
+
+<CardGrid>
+  <LinkCard
+    title="Observability"
+    description="Monitoring, metrics, and application insights."
+    href="https://f5xc-salesdemos.github.io/observability/"
+  />
+  <LinkCard
+    title="Administration"
+    description="Tenant management, RBAC, and platform settings."
+    href="https://f5xc-salesdemos.github.io/administration/"
+  />
+</CardGrid>
+
+## Platform &amp; Tooling
 
 <CardGrid>
   <LinkCard


### PR DESCRIPTION
## Summary

- Switch landing page to Starlight `splash` template with hero section (tagline + action buttons)
- Add LinkCards for all 16 documentation-enabled repos from the org
- Organize repos into 4 categorized CardGrids: Security Solutions, Networking & Performance, Operations, Platform & Tooling
- Remove repetitive "F5 XC" prefixes from card descriptions since the page title provides context

Closes #17

## Test plan

- [ ] Run local dev server and confirm splash layout renders (full-width, no sidebar, hero visible)
- [ ] Verify all LinkCards point to correct GitHub Pages URLs
- [ ] Check that `&amp;` renders correctly in section headings

🤖 Generated with [Claude Code](https://claude.com/claude-code)