### PR TITLE
docs: update landing page title to reflect Sales Demos project

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,8 +1,8 @@
 ---
-title: F5 Distributed Cloud
+title: F5 Distributed Cloud Sales Demos
 template: splash
 hero:
-  tagline: Sales engineering documentation and demo guides for F5 Distributed Cloud solutions.
+  tagline: Demo guides and runbooks for F5 Distributed Cloud sales engineering.
   actions:
     - text: Get Started
       link: https://f5xc-salesdemos.github.io/docs-builder/


### PR DESCRIPTION
## Summary

- Title: "F5 Distributed Cloud" → "F5 Distributed Cloud Sales Demos"
- Tagline: "Sales engineering documentation and demo guides..." → "Demo guides and runbooks for F5 Distributed Cloud sales engineering."

Closes #19

## Test plan

- [ ] Verify the site title in the browser tab reads "F5 Distributed Cloud Sales Demos"
- [ ] Confirm the hero tagline renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)