### PR TITLE
docs: remove hero actions from landing page splash

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -3,15 +3,6 @@ title: F5 Distributed Cloud Sales Demos
 template: splash
 hero:
   tagline: Demo guides and runbooks for F5 Distributed Cloud sales engineering.
-  actions:
-    - text: Get Started
-      link: https://f5xc-salesdemos.github.io/docs-builder/
-      icon: right-arrow
-      variant: primary
-    - text: View on GitHub
-      link: https://github.com/f5xc-salesdemos
-      icon: external
-      variant: minimal
 ---
 
 import { LinkCard, CardGrid } from '@astrojs/starlight/components';


### PR DESCRIPTION
Closes #27

## Summary
Removes the hero action buttons (Get Started, View on GitHub) from the landing page splash template to simplify the initial user experience.

## Changes
- Removed  section from docs/index.mdx
- Landing page now displays only the tagline and content card sections

## Impact
- Cleaner, more minimal landing page
- Users still have access to all documentation through content cards