### PR TITLE
docs: add F5 brand icons to landing page LinkCards

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -11,36 +11,43 @@ import { LinkCard, CardGrid } from '@astrojs/starlight/components';
 
 <CardGrid>
   <LinkCard
+    icon="f5-brand:security-firewall"
     title="WAF"
     description="Web application firewall configuration and policies."
     href="https://f5xc-salesdemos.github.io/waf/"
   />
   <LinkCard
+    icon="f5-brand:network-api-gateway"
     title="API"
     description="API discovery, protection, and security policies."
     href="https://f5xc-salesdemos.github.io/api/"
   />
   <LinkCard
+    icon="f5-brand:security-bot-defence"
     title="Bot Advanced"
     description="Advanced bot defense with behavioral analysis."
     href="https://f5xc-salesdemos.github.io/bot-advanced/"
   />
   <LinkCard
+    icon="f5-brand:security-bot"
     title="Bot Standard"
     description="Standard bot defense with signature-based detection."
     href="https://f5xc-salesdemos.github.io/bot-standard/"
   />
   <LinkCard
+    icon="f5-brand:security-shield-app-code"
     title="CSD"
     description="Client-side defense for browser-based threats."
     href="https://f5xc-salesdemos.github.io/csd/"
   />
   <LinkCard
+    icon="f5-brand:network-ddos-protection"
     title="DDoS"
     description="Distributed denial-of-service protection."
     href="https://f5xc-salesdemos.github.io/ddos/"
   />
   <LinkCard
+    icon="f5-brand:security-shield-magnifying-code"
     title="WAS"
     description="Web application scanning and vulnerability assessment."
     href="https://f5xc-salesdemos.github.io/was/"
@@ -51,21 +58,25 @@ import { LinkCard, CardGrid } from '@astrojs/starlight/components';
 
 <CardGrid>
   <LinkCard
+    icon="f5-brand:cloud-multi-network"
     title="MCN"
     description="Multi-cloud networking and site connectivity."
     href="https://f5xc-salesdemos.github.io/mcn/"
   />
   <LinkCard
+    icon="f5-brand:cloud-edge-computing"
     title="CDN"
     description="Content delivery network and edge caching."
     href="https://f5xc-salesdemos.github.io/cdn/"
   />
   <LinkCard
+    icon="f5-brand:network-dns-1"
     title="DNS"
     description="DNS management, zones, and load balancing."
     href="https://f5xc-salesdemos.github.io/dns/"
   />
   <LinkCard
+    icon="f5-brand:service-nginx"
     title="NGINX"
     description="NGINX integration and configuration management."
     href="https://f5xc-salesdemos.github.io/nginx/"
@@ -76,11 +87,13 @@ import { LinkCard, CardGrid } from '@astrojs/starlight/components';
 
 <CardGrid>
   <LinkCard
+    icon="f5-brand:site-data-insights-magnifying-glass"
     title="Observability"
     description="Monitoring, metrics, and application insights."
     href="https://f5xc-salesdemos.github.io/observability/"
   />
   <LinkCard
+    icon="f5-brand:user-admin"
     title="Administration"
     description="Tenant management, RBAC, and platform settings."
     href="https://f5xc-salesdemos.github.io/administration/"
@@ -91,16 +104,19 @@ import { LinkCard, CardGrid } from '@astrojs/starlight/components';
 
 <CardGrid>
   <LinkCard
+    icon="f5-brand:doc-code"
     title="Docs Builder"
     description="Containerized Astro + Starlight documentation build system."
     href="https://f5xc-salesdemos.github.io/docs-builder/"
   />
   <LinkCard
+    icon="f5-brand:guide-star"
     title="Docs Theme"
     description="Shared branding and styling for documentation sites."
     href="https://f5xc-salesdemos.github.io/docs-theme/"
   />
   <LinkCard
+    icon="f5-brand:image"
     title="Docs Icons"
     description="NPM icon packages and plugins for the documentation build system."
     href="https://f5xc-salesdemos.github.io/docs-icons/"


### PR DESCRIPTION
## Summary
- Add `icon` prop with `f5-brand:` icons to all 16 LinkCards on the landing page
- Icons sourced from the `@robinmordasiewicz/icons-f5-brand` package via `starlight-plugin-icons`
- Each icon visually represents the linked documentation site (e.g., firewall for WAF, bot for Bot Defense)

Closes #38

## Test plan
- [ ] CI checks pass (linting, build)
- [ ] GitHub Pages deploy workflow succeeds after merge
- [ ] Landing page at https://f5xc-salesdemos.github.io/docs/ renders each card with its icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)