### PR TITLE
docs: remove redundant Docs prefix from Platform & Tooling titles

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -105,19 +105,19 @@ import { LinkCard, CardGrid } from '@astrojs/starlight/components';
 <CardGrid>
   <LinkCard
     icon="f5-brand:doc-code"
-    title="Docs Builder"
+    title="Builder"
     description="Containerized Astro + Starlight documentation build system."
     href="https://f5xc-salesdemos.github.io/docs-builder/"
   />
   <LinkCard
     icon="f5-brand:guide-star"
-    title="Docs Theme"
+    title="Theme"
     description="Shared branding and styling for documentation sites."
     href="https://f5xc-salesdemos.github.io/docs-theme/"
   />
   <LinkCard
     icon="f5-brand:image"
-    title="Docs Icons"
+    title="Icons"
     description="NPM icon packages and plugins for the documentation build system."
     href="https://f5xc-salesdemos.github.io/docs-icons/"
   />


### PR DESCRIPTION
## Summary
- Rename "Docs Builder" → "Builder", "Docs Theme" → "Theme", "Docs Icons" → "Icons"
- The section heading "Platform & Tooling" already implies documentation context, so the repeated prefix is redundant

Closes #40

## Test plan
- [ ] CI checks pass
- [ ] GitHub Pages deploy succeeds after merge
- [ ] Card titles render as "Builder", "Theme", "Icons" on the landing page

🤖 Generated with [Claude Code](https://claude.com/claude-code)