### PR TITLE
docs: switch landing page icons to f5xc service icons

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -11,43 +11,43 @@ import { LinkCard, CardGrid } from '@astrojs/starlight/components';
 
 <CardGrid>
   <LinkCard
-    icon="f5-brand:security-firewall"
+    icon="f5xc:web-app-and-api-protection"
     title="WAF"
     description="Web application firewall configuration and policies."
     href="https://f5xc-salesdemos.github.io/waf/"
   />
   <LinkCard
-    icon="f5-brand:network-api-gateway"
+    icon="f5xc:web-app-and-api-protection"
     title="API"
     description="API discovery, protection, and security policies."
     href="https://f5xc-salesdemos.github.io/api/"
   />
   <LinkCard
-    icon="f5-brand:security-bot-defence"
+    icon="f5xc:bot-defense"
     title="Bot Advanced"
     description="Advanced bot defense with behavioral analysis."
     href="https://f5xc-salesdemos.github.io/bot-advanced/"
   />
   <LinkCard
-    icon="f5-brand:security-bot"
+    icon="f5xc:bot-defense"
     title="Bot Standard"
     description="Standard bot defense with signature-based detection."
     href="https://f5xc-salesdemos.github.io/bot-standard/"
   />
   <LinkCard
-    icon="f5-brand:security-shield-app-code"
+    icon="f5xc:client-side-defense"
     title="CSD"
     description="Client-side defense for browser-based threats."
     href="https://f5xc-salesdemos.github.io/csd/"
   />
   <LinkCard
-    icon="f5-brand:network-ddos-protection"
+    icon="f5xc:ddos-and-transit-services"
     title="DDoS"
     description="Distributed denial-of-service protection."
     href="https://f5xc-salesdemos.github.io/ddos/"
   />
   <LinkCard
-    icon="f5-brand:security-shield-magnifying-code"
+    icon="f5xc:web-app-scanning"
     title="WAS"
     description="Web application scanning and vulnerability assessment."
     href="https://f5xc-salesdemos.github.io/was/"
@@ -58,25 +58,25 @@ import { LinkCard, CardGrid } from '@astrojs/starlight/components';
 
 <CardGrid>
   <LinkCard
-    icon="f5-brand:cloud-multi-network"
+    icon="f5xc:multi-cloud-network-connect"
     title="MCN"
     description="Multi-cloud networking and site connectivity."
     href="https://f5xc-salesdemos.github.io/mcn/"
   />
   <LinkCard
-    icon="f5-brand:cloud-edge-computing"
+    icon="f5xc:content-delivery-network"
     title="CDN"
     description="Content delivery network and edge caching."
     href="https://f5xc-salesdemos.github.io/cdn/"
   />
   <LinkCard
-    icon="f5-brand:network-dns-1"
+    icon="f5xc:dns-management"
     title="DNS"
     description="DNS management, zones, and load balancing."
     href="https://f5xc-salesdemos.github.io/dns/"
   />
   <LinkCard
-    icon="f5-brand:service-nginx"
+    icon="f5xc:nginx-one"
     title="NGINX"
     description="NGINX integration and configuration management."
     href="https://f5xc-salesdemos.github.io/nginx/"
@@ -87,13 +87,13 @@ import { LinkCard, CardGrid } from '@astrojs/starlight/components';
 
 <CardGrid>
   <LinkCard
-    icon="f5-brand:site-data-insights-magnifying-glass"
+    icon="f5xc:observability"
     title="Observability"
     description="Monitoring, metrics, and application insights."
     href="https://f5xc-salesdemos.github.io/observability/"
   />
   <LinkCard
-    icon="f5-brand:user-admin"
+    icon="f5xc:administration"
     title="Administration"
     description="Tenant management, RBAC, and platform settings."
     href="https://f5xc-salesdemos.github.io/administration/"
@@ -104,19 +104,19 @@ import { LinkCard, CardGrid } from '@astrojs/starlight/components';
 
 <CardGrid>
   <LinkCard
-    icon="f5-brand:doc-code"
+    icon="f5xc:doc"
     title="Builder"
     description="Containerized Astro + Starlight documentation build system."
     href="https://f5xc-salesdemos.github.io/docs-builder/"
   />
   <LinkCard
-    icon="f5-brand:guide-star"
+    icon="f5xc:platform"
     title="Theme"
     description="Shared branding and styling for documentation sites."
     href="https://f5xc-salesdemos.github.io/docs-theme/"
   />
   <LinkCard
-    icon="f5-brand:image"
+    icon="f5xc:shared-configuration"
     title="Icons"
     description="NPM icon packages and plugins for the documentation build system."
     href="https://f5xc-salesdemos.github.io/docs-icons/"


### PR DESCRIPTION
## Summary
- Replace all `f5-brand:` icons with `f5xc:` icons from the F5 Distributed Cloud service icon pack
- The f5xc icons are purpose-built to represent XC services and adapt to light/dark themes via CSS custom properties
- 13 cards have exact service matches; 3 Platform & Tooling cards use closest-fit icons (`doc`, `platform`, `shared-configuration`)

Closes #44

## Test plan
- [ ] CI checks pass
- [ ] GitHub Pages deploy succeeds after merge
- [ ] Landing page renders f5xc service icons on all cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)