### PR TITLE
docs: remove non-functional icon props from LinkCards

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -11,43 +11,36 @@ import { LinkCard, CardGrid } from '@astrojs/starlight/components';
 
 <CardGrid>
   <LinkCard
-    icon="f5xc:web-app-and-api-protection"
     title="WAF"
     description="Web application firewall configuration and policies."
     href="https://f5xc-salesdemos.github.io/waf/"
   />
   <LinkCard
-    icon="f5xc:web-app-and-api-protection"
     title="API"
     description="API discovery, protection, and security policies."
     href="https://f5xc-salesdemos.github.io/api/"
   />
   <LinkCard
-    icon="f5xc:bot-defense"
     title="Bot Advanced"
     description="Advanced bot defense with behavioral analysis."
     href="https://f5xc-salesdemos.github.io/bot-advanced/"
   />
   <LinkCard
-    icon="f5xc:bot-defense"
     title="Bot Standard"
     description="Standard bot defense with signature-based detection."
     href="https://f5xc-salesdemos.github.io/bot-standard/"
   />
   <LinkCard
-    icon="f5xc:client-side-defense"
     title="CSD"
     description="Client-side defense for browser-based threats."
     href="https://f5xc-salesdemos.github.io/csd/"
   />
   <LinkCard
-    icon="f5xc:ddos-and-transit-services"
     title="DDoS"
     description="Distributed denial-of-service protection."
     href="https://f5xc-salesdemos.github.io/ddos/"
   />
   <LinkCard
-    icon="f5xc:web-app-scanning"
     title="WAS"
     description="Web application scanning and vulnerability assessment."
     href="https://f5xc-salesdemos.github.io/was/"
@@ -58,25 +51,21 @@ import { LinkCard, CardGrid } from '@astrojs/starlight/components';
 
 <CardGrid>
   <LinkCard
-    icon="f5xc:multi-cloud-network-connect"
     title="MCN"
     description="Multi-cloud networking and site connectivity."
     href="https://f5xc-salesdemos.github.io/mcn/"
   />
   <LinkCard
-    icon="f5xc:content-delivery-network"
     title="CDN"
     description="Content delivery network and edge caching."
     href="https://f5xc-salesdemos.github.io/cdn/"
   />
   <LinkCard
-    icon="f5xc:dns-management"
     title="DNS"
     description="DNS management, zones, and load balancing."
     href="https://f5xc-salesdemos.github.io/dns/"
   />
   <LinkCard
-    icon="f5xc:nginx-one"
     title="NGINX"
     description="NGINX integration and configuration management."
     href="https://f5xc-salesdemos.github.io/nginx/"
@@ -87,13 +76,11 @@ import { LinkCard, CardGrid } from '@astrojs/starlight/components';
 
 <CardGrid>
   <LinkCard
-    icon="f5xc:observability"
     title="Observability"
     description="Monitoring, metrics, and application insights."
     href="https://f5xc-salesdemos.github.io/observability/"
   />
   <LinkCard
-    icon="f5xc:administration"
     title="Administration"
     description="Tenant management, RBAC, and platform settings."
     href="https://f5xc-salesdemos.github.io/administration/"
@@ -104,19 +91,16 @@ import { LinkCard, CardGrid } from '@astrojs/starlight/components';
 
 <CardGrid>
   <LinkCard
-    icon="f5xc:doc"
     title="Builder"
     description="Containerized Astro + Starlight documentation build system."
     href="https://f5xc-salesdemos.github.io/docs-builder/"
   />
   <LinkCard
-    icon="f5xc:platform"
     title="Theme"
     description="Shared branding and styling for documentation sites."
     href="https://f5xc-salesdemos.github.io/docs-theme/"
   />
   <LinkCard
-    icon="f5xc:shared-configuration"
     title="Icons"
     description="NPM icon packages and plugins for the documentation build system."
     href="https://f5xc-salesdemos.github.io/docs-icons/"


### PR DESCRIPTION
## Summary
- Remove `icon` props from all 16 LinkCards — Starlight's `LinkCard` does not support this prop
- The icon values were silently passed as HTML `<a>` attributes and never rendered as visual icons
- Proper LinkCard icon support is tracked in f5xc-salesdemos/docs-theme#121

Closes #46

## Test plan
- [ ] CI checks pass
- [ ] GitHub Pages deploy succeeds
- [ ] Landing page renders cleanly without stray HTML attributes

🤖 Generated with [Claude Code](https://claude.com/claude-code)