### PR TITLE
docs: add f5xc service icons to landing page LinkCards

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -11,36 +11,43 @@ import { LinkCard, CardGrid } from '@astrojs/starlight/components';
 
 <CardGrid>
   <LinkCard
+    icon="f5xc:web-app-and-api-protection"
     title="WAF"
     description="Web application firewall configuration and policies."
     href="https://f5xc-salesdemos.github.io/waf/"
   />
   <LinkCard
+    icon="f5xc:web-app-and-api-protection"
     title="API"
     description="API discovery, protection, and security policies."
     href="https://f5xc-salesdemos.github.io/api/"
   />
   <LinkCard
+    icon="f5xc:bot-defense"
     title="Bot Advanced"
     description="Advanced bot defense with behavioral analysis."
     href="https://f5xc-salesdemos.github.io/bot-advanced/"
   />
   <LinkCard
+    icon="f5xc:bot-defense"
     title="Bot Standard"
     description="Standard bot defense with signature-based detection."
     href="https://f5xc-salesdemos.github.io/bot-standard/"
   />
   <LinkCard
+    icon="f5xc:client-side-defense"
     title="CSD"
     description="Client-side defense for browser-based threats."
     href="https://f5xc-salesdemos.github.io/csd/"
   />
   <LinkCard
+    icon="f5xc:ddos-and-transit-services"
     title="DDoS"
     description="Distributed denial-of-service protection."
     href="https://f5xc-salesdemos.github.io/ddos/"
   />
   <LinkCard
+    icon="f5xc:web-app-scanning"
     title="WAS"
     description="Web application scanning and vulnerability assessment."
     href="https://f5xc-salesdemos.github.io/was/"
@@ -51,21 +58,25 @@ import { LinkCard, CardGrid } from '@astrojs/starlight/components';
 
 <CardGrid>
   <LinkCard
+    icon="f5xc:multi-cloud-network-connect"
     title="MCN"
     description="Multi-cloud networking and site connectivity."
     href="https://f5xc-salesdemos.github.io/mcn/"
   />
   <LinkCard
+    icon="f5xc:content-delivery-network"
     title="CDN"
     description="Content delivery network and edge caching."
     href="https://f5xc-salesdemos.github.io/cdn/"
   />
   <LinkCard
+    icon="f5xc:dns-management"
     title="DNS"
     description="DNS management, zones, and load balancing."
     href="https://f5xc-salesdemos.github.io/dns/"
   />
   <LinkCard
+    icon="f5xc:nginx-one"
     title="NGINX"
     description="NGINX integration and configuration management."
     href="https://f5xc-salesdemos.github.io/nginx/"
@@ -76,11 +87,13 @@ import { LinkCard, CardGrid } from '@astrojs/starlight/components';
 
 <CardGrid>
   <LinkCard
+    icon="f5xc:observability"
     title="Observability"
     description="Monitoring, metrics, and application insights."
     href="https://f5xc-salesdemos.github.io/observability/"
   />
   <LinkCard
+    icon="f5xc:administration"
     title="Administration"
     description="Tenant management, RBAC, and platform settings."
     href="https://f5xc-salesdemos.github.io/administration/"
@@ -91,16 +104,19 @@ import { LinkCard, CardGrid } from '@astrojs/starlight/components';
 
 <CardGrid>
   <LinkCard
+    icon="f5xc:doc"
     title="Builder"
     description="Containerized Astro + Starlight documentation build system."
     href="https://f5xc-salesdemos.github.io/docs-builder/"
   />
   <LinkCard
+    icon="f5xc:platform"
     title="Theme"
     description="Shared branding and styling for documentation sites."
     href="https://f5xc-salesdemos.github.io/docs-theme/"
   />
   <LinkCard
+    icon="f5xc:shared-configuration"
     title="Icons"
     description="NPM icon packages and plugins for the documentation build system."
     href="https://f5xc-salesdemos.github.io/docs-icons/"


### PR DESCRIPTION
## Summary
- Add `icon` prop with `f5xc:` service icons to all 16 LinkCards on the landing page
- Icons sourced from `@robinmordasiewicz/icons-f5xc` — purpose-built F5 XC service icons with light/dark theme adaptation
- Now functional thanks to LinkCard icon override in docs-theme (f5xc-salesdemos/docs-theme#121)

Closes #48

## Test plan
- [ ] CI checks pass
- [ ] GitHub Pages deploy succeeds
- [ ] Icons render on all cards in both dark and light mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)