### PR TITLE
docs: import custom LinkCard from docs-theme for icon support

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -5,7 +5,8 @@ hero:
   tagline: Demo guides and runbooks for F5 Distributed Cloud sales engineering.
 ---
 
-import { LinkCard, CardGrid } from '@astrojs/starlight/components';
+import { CardGrid } from '@astrojs/starlight/components';
+import LinkCard from 'f5xc-docs-theme/components/LinkCard.astro';
 
 ## Security Solutions
 


### PR DESCRIPTION
## Summary
- Import `LinkCard` from `f5xc-docs-theme/components/LinkCard.astro` instead of `@astrojs/starlight/components`
- The stock Starlight `LinkCard` doesn't support the `icon` prop — it passes it as a raw HTML attribute
- The theme's custom `LinkCard` (added in v1.7.0) renders icons via the `Icon.astro` component

Closes #50

## Test plan
- [ ] CI checks pass (build succeeds with the new import)
- [ ] GitHub Pages deploy succeeds
- [ ] Icons visually render on all cards in both dark and light mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)