### PR TITLE
fix: switch to f5-brand icons to fix broken build

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -12,43 +12,43 @@ import LinkCard from 'f5xc-docs-theme/components/LinkCard.astro';
 
 <CardGrid>
   <LinkCard
-    icon="f5xc:web-app-and-api-protection"
+    icon="f5-brand:security-firewall"
     title="WAF"
     description="Web application firewall configuration and policies."
     href="https://f5xc-salesdemos.github.io/waf/"
   />
   <LinkCard
-    icon="f5xc:web-app-and-api-protection"
+    icon="f5-brand:network-api-gateway"
     title="API"
     description="API discovery, protection, and security policies."
     href="https://f5xc-salesdemos.github.io/api/"
   />
   <LinkCard
-    icon="f5xc:bot-defense"
+    icon="f5-brand:security-bot-defence"
     title="Bot Advanced"
     description="Advanced bot defense with behavioral analysis."
     href="https://f5xc-salesdemos.github.io/bot-advanced/"
   />
   <LinkCard
-    icon="f5xc:bot-defense"
+    icon="f5-brand:security-bot"
     title="Bot Standard"
     description="Standard bot defense with signature-based detection."
     href="https://f5xc-salesdemos.github.io/bot-standard/"
   />
   <LinkCard
-    icon="f5xc:client-side-defense"
+    icon="f5-brand:security-shield-app-code"
     title="CSD"
     description="Client-side defense for browser-based threats."
     href="https://f5xc-salesdemos.github.io/csd/"
   />
   <LinkCard
-    icon="f5xc:ddos-and-transit-services"
+    icon="f5-brand:network-ddos-protection"
     title="DDoS"
     description="Distributed denial-of-service protection."
     href="https://f5xc-salesdemos.github.io/ddos/"
   />
   <LinkCard
-    icon="f5xc:web-app-scanning"
+    icon="f5-brand:security-shield-magnifying-code"
     title="WAS"
     description="Web application scanning and vulnerability assessment."
     href="https://f5xc-salesdemos.github.io/was/"
@@ -59,25 +59,25 @@ import LinkCard from 'f5xc-docs-theme/components/LinkCard.astro';
 
 <CardGrid>
   <LinkCard
-    icon="f5xc:multi-cloud-network-connect"
+    icon="f5-brand:cloud-multi-network"
     title="MCN"
     description="Multi-cloud networking and site connectivity."
     href="https://f5xc-salesdemos.github.io/mcn/"
   />
   <LinkCard
-    icon="f5xc:content-delivery-network"
+    icon="f5-brand:cloud-edge-computing"
     title="CDN"
     description="Content delivery network and edge caching."
     href="https://f5xc-salesdemos.github.io/cdn/"
   />
   <LinkCard
-    icon="f5xc:dns-management"
+    icon="f5-brand:network-dns-1"
     title="DNS"
     description="DNS management, zones, and load balancing."
     href="https://f5xc-salesdemos.github.io/dns/"
   />
   <LinkCard
-    icon="f5xc:nginx-one"
+    icon="f5-brand:service-nginx"
     title="NGINX"
     description="NGINX integration and configuration management."
     href="https://f5xc-salesdemos.github.io/nginx/"
@@ -88,13 +88,13 @@ import LinkCard from 'f5xc-docs-theme/components/LinkCard.astro';
 
 <CardGrid>
   <LinkCard
-    icon="f5xc:observability"
+    icon="f5-brand:site-data-insights-magnifying-glass"
     title="Observability"
     description="Monitoring, metrics, and application insights."
     href="https://f5xc-salesdemos.github.io/observability/"
   />
   <LinkCard
-    icon="f5xc:administration"
+    icon="f5-brand:user-admin"
     title="Administration"
     description="Tenant management, RBAC, and platform settings."
     href="https://f5xc-salesdemos.github.io/administration/"
@@ -105,19 +105,19 @@ import LinkCard from 'f5xc-docs-theme/components/LinkCard.astro';
 
 <CardGrid>
   <LinkCard
-    icon="f5xc:doc"
+    icon="f5-brand:doc-code"
     title="Builder"
     description="Containerized Astro + Starlight documentation build system."
     href="https://f5xc-salesdemos.github.io/docs-builder/"
   />
   <LinkCard
-    icon="f5xc:platform"
+    icon="f5-brand:guide-star"
     title="Theme"
     description="Shared branding and styling for documentation sites."
     href="https://f5xc-salesdemos.github.io/docs-theme/"
   />
   <LinkCard
-    icon="f5xc:shared-configuration"
+    icon="f5-brand:image"
     title="Icons"
     description="NPM icon packages and plugins for the documentation build system."
     href="https://f5xc-salesdemos.github.io/docs-icons/"


### PR DESCRIPTION
## Summary
- Switch all `f5xc:` icon prefixes to `f5-brand:` to fix the build failure
- The `f5xc` prefix is not registered in the docs-theme Icon component (tracked in f5xc-salesdemos/docs-theme#130)
- Keeps the custom LinkCard import from docs-theme which supports the `icon` prop
- Uses `f5-brand:` icons from the 665-icon F5 brand pack which is already registered

Closes #52

## Test plan
- [ ] CI checks pass (build no longer fails)
- [ ] GitHub Pages deploy succeeds
- [ ] Icons visually render on all cards in both dark and light mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)