### PR TITLE
fix: correct f5-brand icon names with other- prefix

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -88,7 +88,7 @@ import LinkCard from 'f5xc-docs-theme/components/LinkCard.astro';
 
 <CardGrid>
   <LinkCard
-    icon="f5-brand:site-data-insights-magnifying-glass"
+    icon="f5-brand:other-site-data-insights-magnifying-glass"
     title="Observability"
     description="Monitoring, metrics, and application insights."
     href="https://f5xc-salesdemos.github.io/observability/"
@@ -105,19 +105,19 @@ import LinkCard from 'f5xc-docs-theme/components/LinkCard.astro';
 
 <CardGrid>
   <LinkCard
-    icon="f5-brand:doc-code"
+    icon="f5-brand:other-doc-code"
     title="Builder"
     description="Containerized Astro + Starlight documentation build system."
     href="https://f5xc-salesdemos.github.io/docs-builder/"
   />
   <LinkCard
-    icon="f5-brand:guide-star"
+    icon="f5-brand:other-guide-star"
     title="Theme"
     description="Shared branding and styling for documentation sites."
     href="https://f5xc-salesdemos.github.io/docs-theme/"
   />
   <LinkCard
-    icon="f5-brand:image"
+    icon="f5-brand:other-image"
     title="Icons"
     description="NPM icon packages and plugins for the documentation build system."
     href="https://f5xc-salesdemos.github.io/docs-icons/"


### PR DESCRIPTION
## Summary
- Fix broken build caused by incorrect f5-brand icon names
- Four icons in the Iconify JSON use the `other-` category prefix: `other-site-data-insights-magnifying-glass`, `other-doc-code`, `other-guide-star`, `other-image`
- Without this prefix, the Astro build fails with "Icon not found" errors

## Test plan
- [ ] CI build passes (icons resolve correctly)
- [ ] Landing page renders all 15 LinkCards with icons
- [ ] Verify icons display in both dark and light mode

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)