### PR TITLE
docs: switch landing page icons from f5-brand to f5xc

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -12,43 +12,43 @@ import LinkCard from 'f5xc-docs-theme/components/LinkCard.astro';
 
 <CardGrid>
   <LinkCard
-    icon="f5-brand:security-firewall"
+    icon="f5xc:web-app-and-api-protection"
     title="WAF"
     description="Web application firewall configuration and policies."
     href="https://f5xc-salesdemos.github.io/waf/"
   />
   <LinkCard
-    icon="f5-brand:network-api-gateway"
+    icon="f5xc:web-app-and-api-protection"
     title="API"
     description="API discovery, protection, and security policies."
     href="https://f5xc-salesdemos.github.io/api/"
   />
   <LinkCard
-    icon="f5-brand:security-bot-defence"
+    icon="f5xc:bot-defense"
     title="Bot Advanced"
     description="Advanced bot defense with behavioral analysis."
     href="https://f5xc-salesdemos.github.io/bot-advanced/"
   />
   <LinkCard
-    icon="f5-brand:security-bot"
+    icon="f5xc:bot-defense"
     title="Bot Standard"
     description="Standard bot defense with signature-based detection."
     href="https://f5xc-salesdemos.github.io/bot-standard/"
   />
   <LinkCard
-    icon="f5-brand:security-shield-app-code"
+    icon="f5xc:client-side-defense"
     title="CSD"
     description="Client-side defense for browser-based threats."
     href="https://f5xc-salesdemos.github.io/csd/"
   />
   <LinkCard
-    icon="f5-brand:network-ddos-protection"
+    icon="f5xc:ddos-and-transit-services"
     title="DDoS"
     description="Distributed denial-of-service protection."
     href="https://f5xc-salesdemos.github.io/ddos/"
   />
   <LinkCard
-    icon="f5-brand:security-shield-magnifying-code"
+    icon="f5xc:web-app-scanning"
     title="WAS"
     description="Web application scanning and vulnerability assessment."
     href="https://f5xc-salesdemos.github.io/was/"
@@ -59,25 +59,25 @@ import LinkCard from 'f5xc-docs-theme/components/LinkCard.astro';
 
 <CardGrid>
   <LinkCard
-    icon="f5-brand:cloud-multi-network"
+    icon="f5xc:multi-cloud-network-connect"
     title="MCN"
     description="Multi-cloud networking and site connectivity."
     href="https://f5xc-salesdemos.github.io/mcn/"
   />
   <LinkCard
-    icon="f5-brand:cloud-edge-computing"
+    icon="f5xc:content-delivery-network"
     title="CDN"
     description="Content delivery network and edge caching."
     href="https://f5xc-salesdemos.github.io/cdn/"
   />
   <LinkCard
-    icon="f5-brand:network-dns-1"
+    icon="f5xc:dns-management"
     title="DNS"
     description="DNS management, zones, and load balancing."
     href="https://f5xc-salesdemos.github.io/dns/"
   />
   <LinkCard
-    icon="f5-brand:service-nginx"
+    icon="f5xc:nginx-one"
     title="NGINX"
     description="NGINX integration and configuration management."
     href="https://f5xc-salesdemos.github.io/nginx/"
@@ -88,13 +88,13 @@ import LinkCard from 'f5xc-docs-theme/components/LinkCard.astro';
 
 <CardGrid>
   <LinkCard
-    icon="f5-brand:other-site-data-insights-magnifying-glass"
+    icon="f5xc:observability"
     title="Observability"
     description="Monitoring, metrics, and application insights."
     href="https://f5xc-salesdemos.github.io/observability/"
   />
   <LinkCard
-    icon="f5-brand:user-admin"
+    icon="f5xc:administration"
     title="Administration"
     description="Tenant management, RBAC, and platform settings."
     href="https://f5xc-salesdemos.github.io/administration/"
@@ -105,19 +105,19 @@ import LinkCard from 'f5xc-docs-theme/components/LinkCard.astro';
 
 <CardGrid>
   <LinkCard
-    icon="f5-brand:other-doc-code"
+    icon="f5xc:doc"
     title="Builder"
     description="Containerized Astro + Starlight documentation build system."
     href="https://f5xc-salesdemos.github.io/docs-builder/"
   />
   <LinkCard
-    icon="f5-brand:other-guide-star"
+    icon="f5xc:shared-configuration"
     title="Theme"
     description="Shared branding and styling for documentation sites."
     href="https://f5xc-salesdemos.github.io/docs-theme/"
   />
   <LinkCard
-    icon="f5-brand:other-image"
+    icon="f5xc:platform"
     title="Icons"
     description="NPM icon packages and plugins for the documentation build system."
     href="https://f5xc-salesdemos.github.io/docs-icons/"


### PR DESCRIPTION
## Summary
- Replace all 16 `f5-brand:*` icon references with `f5xc:*` service icons on the landing page
- The `f5xc` prefix is now registered in docs-theme, enabling product-specific service icons

## Test plan
- [ ] CI build passes (confirms `f5xc:` prefix resolves correctly)
- [ ] Icons render on docs site at https://f5xc-salesdemos.github.io/docs/

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)