### PR TITLE
Add docs-control card to landing page

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -122,4 +122,10 @@ import LinkCard from 'f5xc-docs-theme/components/LinkCard.astro';
     description="NPM icon packages and plugins for the documentation build system."
     href="https://f5xc-salesdemos.github.io/docs-icons/"
   />
+  <LinkCard
+    icon="f5xc:shared-configuration"
+    title="Control"
+    description="CI workflows, governance templates, and repo settings enforcement."
+    href="https://f5xc-salesdemos.github.io/docs-control/"
+  />
 </CardGrid>


### PR DESCRIPTION
## Summary
- Adds a LinkCard for docs-control to the "Platform & Tooling" section on the landing page
- docs-control is the source-of-truth repo for CI workflows, governance templates, and repo settings enforcement
- Completes the set: Builder, Theme, Icons, and now Control

Closes #64

## Test plan
- [ ] CI build passes
- [ ] New card renders under "Platform & Tooling" at https://f5xc-salesdemos.github.io/docs/

🤖 Generated with [Claude Code](https://claude.com/claude-code)