### PR TITLE
Replace platform icon on Icons card

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -117,7 +117,7 @@ import LinkCard from 'f5xc-docs-theme/components/LinkCard.astro';
     href="https://f5xc-salesdemos.github.io/docs-theme/"
   />
   <LinkCard
-    icon="f5xc:platform"
+    icon="f5xc:distributed-apps"
     title="Icons"
     description="NPM icon packages and plugins for the documentation build system."
     href="https://f5xc-salesdemos.github.io/docs-icons/"


### PR DESCRIPTION
## Summary
- Changes the Icons LinkCard icon from `f5xc:platform` to `f5xc:distributed-apps`
- `f5xc:platform` is intended for large image display, not card icons
- `f5xc:distributed-apps` better represents distributable icon packages

Closes #66

## Test plan
- [ ] CI build passes
- [ ] Icons card renders with new icon at https://f5xc-salesdemos.github.io/docs/

🤖 Generated with [Claude Code](https://claude.com/claude-code)