### PR TITLE
feat: set hero title to Sales Demos

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -2,6 +2,7 @@
 title: F5 Distributed Cloud Sales Demos
 template: splash
 hero:
+  title: Sales Demos
   tagline: Demo guides and runbooks for F5 Distributed Cloud sales engineering.
   image:
     html: '<img src="/docs/images/hero-platform.svg" alt="F5 Distributed Cloud platform" />'


### PR DESCRIPTION
## Summary
- Adds `hero.title: Sales Demos` to the splash page frontmatter so the hero displays a shorter title
- Page-level `title` remains "F5 Distributed Cloud Sales Demos" for SEO, browser tab, and sidebar navigation

## Test plan
- [ ] CI build passes
- [ ] Hero section displays "Sales Demos" as the heading
- [ ] Browser tab still shows "F5 Distributed Cloud Sales Demos"

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)