### PR TITLE
feat: add AI section to landing page with api-mcp card

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -132,3 +132,14 @@ import LinkCard from 'f5xc-docs-theme/components/LinkCard.astro';
     href="https://f5xc-salesdemos.github.io/docs-control/"
   />
 </CardGrid>
+
+## AI
+
+<CardGrid>
+  <LinkCard
+    icon="f5xc:ai_assistant_logo"
+    title="API MCP"
+    description="MCP server for F5 Distributed Cloud API."
+    href="https://f5xc-salesdemos.github.io/api-mcp/"
+  />
+</CardGrid>


### PR DESCRIPTION
## Summary
- Add new "AI" section to the organization landing page after "Platform & Tooling"
- Include LinkCard for API MCP with link to the api-mcp docs site
- Use `f5xc:ai_assistant_logo` icon

Closes #74

## Test plan
- [ ] Verify landing page shows "AI" section after "Platform & Tooling"
- [ ] Verify card links to https://f5xc-salesdemos.github.io/api-mcp/
- [ ] Verify icon renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)