### PR TITLE
docs: update API docs link to api-protection

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -24,7 +24,7 @@ import LinkCard from 'f5xc-docs-theme/components/LinkCard.astro';
     icon="f5xc:web-app-and-api-protection"
     title="API"
     description="API discovery, protection, and security policies."
-    href="https://f5xc-salesdemos.github.io/api/"
+    href="https://f5xc-salesdemos.github.io/api-protection/"
   />
   <LinkCard
     icon="f5xc:bot-defense"


### PR DESCRIPTION
## Summary
- Updates landing page card href from `/api/` to `/api-protection/` after repo rename

## Test plan
- [ ] CI checks pass
- [ ] After merge, landing page card points to correct URL

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)