### PR TITLE
feat: add Automation section with Terraform Provider

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -104,6 +104,17 @@ import LinkCard from 'f5xc-docs-theme/components/LinkCard.astro';
   />
 </CardGrid>
 
+## Automation
+
+<CardGrid>
+  <LinkCard
+    icon="hashicorp-flight:terraform-color"
+    title="Terraform Provider"
+    description="Terraform provider for F5 Distributed Cloud."
+    href="https://f5xc-salesdemos.github.io/terraform-provider-f5xc/"
+  />
+</CardGrid>
+
 ## Platform &amp; Tooling
 
 <CardGrid>


### PR DESCRIPTION
## Summary
- Add new "Automation" section to docs landing page between "Operations" and "Platform & Tooling"
- Feature a LinkCard for the Terraform Provider using `hashicorp-flight:terraform-color` icon

## Test plan
- [ ] Verify the landing page renders correctly with the new section
- [ ] Confirm the Terraform Provider link navigates to the correct URL
- [ ] Check the icon renders properly

Closes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)