### PR TITLE
fix: update deprecated f5xc-docs-theme import to @f5xc-salesdemos/docs-theme

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -9,7 +9,7 @@ hero:
 ---
 
 import { CardGrid } from '@astrojs/starlight/components';
-import LinkCard from 'f5xc-docs-theme/components/LinkCard.astro';
+import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
 
 ## Security Solutions
 


### PR DESCRIPTION
## Changes

Update the stale `f5xc-docs-theme` import in `docs/index.mdx` to use the new scoped package name `@f5xc-salesdemos/docs-theme`.

## Why

The theme package was renamed from `f5xc-docs-theme` to `@f5xc-salesdemos/docs-theme` (v2.0.0+). The old import causes the Rollup build to fail:

```
Rollup failed to resolve import "f5xc-docs-theme/components/LinkCard.astro"
  from "/app/src/content/docs/index.mdx"
```

## What changed

```diff
- import LinkCard from 'f5xc-docs-theme/components/LinkCard.astro';
+ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
```

## Testing

The export `./components/LinkCard.astro` is confirmed in `docs-theme`'s `package.json` exports map. After merge, the GitHub Pages Deploy workflow should succeed and the docs site should be accessible at https://f5xc-salesdemos.github.io/docs/

Closes #113