### PR TITLE
docs: add Dev Container card to landing page

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -142,6 +142,12 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     description="CI workflows, governance templates, and repo settings enforcement."
     href="https://f5xc-salesdemos.github.io/docs-control/"
   />
+  <LinkCard
+    icon="hashicorp-flight:docker-color"
+    title="Dev Container"
+    description="Isolated development environment with AI coding tools."
+    href="https://f5xc-salesdemos.github.io/devcontainer/"
+  />
 </CardGrid>
 
 ## AI


### PR DESCRIPTION
## Summary

Add a Dev Container LinkCard to the Platform & Tooling section of the organization landing page.

## Changes

- `docs/index.mdx` — Add LinkCard for Dev Container
  - Icon: `hashicorp-flight:docker-color` (Docker whale)
  - Title: Dev Container
  - Description: Isolated development environment with AI coding tools.
  - Links to `https://f5xc-salesdemos.github.io/devcontainer/`

## Testing

- Landing page renders the Dev Container card in the Platform & Tooling section
- Card links to the live devcontainer docs site

Closes #123