### PR TITLE
Add marketplace to AI section of landing page

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -159,4 +159,10 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     description="MCP server for F5 Distributed Cloud API."
     href="https://f5xc-salesdemos.github.io/api-mcp/"
   />
+  <LinkCard
+    icon="f5xc:ai_assistant_logo"
+    title="Marketplace"
+    description="AI-powered marketplace for F5 Distributed Cloud solutions."
+    href="https://f5xc-salesdemos.github.io/marketplace/"
+  />
 </CardGrid>


### PR DESCRIPTION
## Summary
- Adds a LinkCard for the marketplace repo under the AI section of the docs landing page
- Uses the `f5xc:ai_assistant_logo` icon consistent with other AI entries

## Test plan
- [ ] Verify the landing page renders the new Marketplace card in the AI section
- [ ] Verify the link points to the correct URL

Closes #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)