### PR TITLE
feat: add claude-code-proxy card to AI section

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -165,4 +165,10 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     description="AI-powered marketplace for F5 Distributed Cloud solutions."
     href="https://f5xc-salesdemos.github.io/marketplace/"
   />
+  <LinkCard
+    icon="f5xc:ai_assistant_logo"
+    title="Claude Code Proxy"
+    description="API proxy translating Claude requests to OpenAI-compatible providers."
+    href="https://f5xc-salesdemos.github.io/claude-code-proxy/"
+  />
 </CardGrid>


### PR DESCRIPTION
## Summary

Add a LinkCard for Claude Code Proxy in the AI section of the docs landing page.

## Related Issue

Closes #127

## Changes

- Added a new `LinkCard` for Claude Code Proxy in the AI section of `docs/index.mdx`, after the Marketplace card

## Checklist

- [x] Linked to a GitHub issue (required — CI will block merge without it)
- [x] Tested locally
- [x] Follows project conventions