### PR TITLE
chore: remove claude-code-proxy references

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -165,10 +165,4 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     description="AI-powered marketplace for F5 Distributed Cloud solutions."
     href="https://f5xc-salesdemos.github.io/marketplace/"
   />
-  <LinkCard
-    icon="f5xc:ai_assistant_logo"
-    title="Claude Code Proxy"
-    description="API proxy translating Claude requests to OpenAI-compatible providers."
-    href="https://f5xc-salesdemos.github.io/claude-code-proxy/"
-  />
 </CardGrid>


### PR DESCRIPTION
## Summary
- Remove Claude Code Proxy `<LinkCard>` from the docs landing page (`docs/index.mdx`)

## Context
The claude-code-proxy repo has been stripped of ecosystem artifacts (PR f5xc-salesdemos/claude-code-proxy#62). This upstream reference should be cleaned up so the org's docs landing page stops linking to a docs site that no longer exists.

Closes #135

🤖 Generated with [Claude Code](https://claude.com/claude-code)