### PR TITLE
feat: add api-specs to landing page

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -113,6 +113,12 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     description="Terraform provider for F5 Distributed Cloud."
     href="https://f5xc-salesdemos.github.io/terraform-provider-f5xc/"
   />
+  <LinkCard
+    icon="f5xc:data-intelligence"
+    title="API Specs"
+    description="OpenAPI spec validation and reconciliation for F5 Distributed Cloud."
+    href="https://f5xc-salesdemos.github.io/api-specs/"
+  />
 </CardGrid>
 
 ## Platform &amp; Tooling


### PR DESCRIPTION
## Summary

- Add API Specs LinkCard to the Automation section of the organization landing page
- Links to the newly onboarded api-specs repository docs site

Closes #184

## Test plan

- [ ] CI checks pass
- [ ] Landing page renders correctly with the new card
- [ ] Link to https://f5xc-salesdemos.github.io/api-specs/ is accessible