### PR TITLE
feat: add api-specs-enriched to landing page

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -119,6 +119,12 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     description="OpenAPI spec validation and reconciliation for F5 Distributed Cloud."
     href="https://f5xc-salesdemos.github.io/api-specs/"
   />
+  <LinkCard
+    icon="f5xc:data-intelligence"
+    title="API Specs Enriched"
+    description="Enriched OpenAPI specifications for F5 Distributed Cloud."
+    href="https://f5xc-salesdemos.github.io/api-specs-enriched/"
+  />
 </CardGrid>
 
 ## Platform &amp; Tooling


### PR DESCRIPTION
## Summary

- Add API Specs Enriched LinkCard to the Automation section of the organization landing page
- Links to the newly onboarded `api-specs-enriched` repository documentation site

Closes #188

## Test plan

- [ ] CI checks pass
- [ ] Verify the LinkCard renders correctly on the landing page
- [ ] Verify the link to `https://f5xc-salesdemos.github.io/api-specs-enriched/` resolves