### PR TITLE
chore: sync managed files from governance template

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -15,5 +15,8 @@ indent_size = unset
 [*.mdx]
 indent_size = unset
 
+[*.py]
+indent_size = 4
+
 [Makefile]
 indent_style = tab


### PR DESCRIPTION
Closes #200

Synced managed files from `f5xc-salesdemos/docs-control` canonical source:

- .editorconfig
- .gitignore
- .pre-commit-config.yaml
- .checkov.yaml
- zizmor.yaml
- .codespellrc
- .prettierignore
- .trivyignore
- .claude/governance.json