### PR TITLE
feat: add oh-my-xcsh to landing page

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -177,4 +177,10 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     description="AI-powered marketplace for F5 Distributed Cloud solutions."
     href="https://f5xc-salesdemos.github.io/marketplace/"
   />
+  <LinkCard
+    icon="f5xc:ai_assistant_logo"
+    title="Oh My XCSh"
+    description="Multi-model agent orchestration plugin for OpenCode."
+    href="https://f5xc-salesdemos.github.io/oh-my-xcsh/"
+  />
 </CardGrid>


### PR DESCRIPTION
## Summary
- Add Oh My XCSh LinkCard to the AI section of the documentation hub

## Test plan
- [ ] Verify index.mdx renders correctly
- [ ] After merge, confirm card appears in AI section

Closes #216

Generated with [Claude Code](https://claude.com/claude-code)