### PR TITLE
chore: remove deprecated xcsh LinkCards from landing page

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -177,16 +177,4 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     description="AI-powered marketplace for F5 Distributed Cloud solutions."
     href="https://f5xc-salesdemos.github.io/marketplace/"
   />
-  <LinkCard
-    icon="f5xc:ai_assistant_logo"
-    title="Oh My XCSh"
-    description="Multi-model agent orchestration plugin for OpenCode."
-    href="https://f5xc-salesdemos.github.io/oh-my-xcsh/"
-  />
-  <LinkCard
-    icon="f5xc:ai_assistant_logo"
-    title="XCSh"
-    description="AI-powered development environment and CLI tool."
-    href="https://f5xc-salesdemos.github.io/xcsh/"
-  />
 </CardGrid>


### PR DESCRIPTION
## Summary
- Removed Oh My XCSh and XCSh LinkCard components from `docs/index.mdx`
- These repos are being deprecated and their GitHub Pages links will stop working

## Test plan
- [ ] Verify landing page renders correctly without the removed cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)