### PR TITLE
chore: remove deprecated xcsh LinkCard from landing page

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -177,10 +177,4 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     description="AI-powered marketplace for F5 Distributed Cloud solutions."
     href="https://f5xc-salesdemos.github.io/marketplace/"
   />
-  <LinkCard
-    icon="f5xc:ai_assistant_logo"
-    title="XCSh"
-    description="AI-powered development environment and CLI tool."
-    href="https://f5xc-salesdemos.github.io/xcsh/"
-  />
 </CardGrid>


### PR DESCRIPTION
## Summary
Remove the xcsh `<LinkCard>` from the AI `<CardGrid>` in `docs/index.mdx`. The `xcsh` repo is deprecated and the GitHub Pages link will stop working.

Closes #279

## Test plan
- [ ] `check / Check linked issues` passes
- [ ] `lint / Lint Code Base` passes
- [ ] Landing page renders correctly without the xcsh card