### PR TITLE
chore: remove oh-my-xcsh LinkCard from docs homepage

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -179,12 +179,6 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
   />
   <LinkCard
     icon="f5xc:ai_assistant_logo"
-    title="Oh My XCSh"
-    description="Multi-model agent orchestration plugin for OpenCode."
-    href="https://f5xc-salesdemos.github.io/oh-my-xcsh/"
-  />
-  <LinkCard
-    icon="f5xc:ai_assistant_logo"
     title="XCSh"
     description="AI-powered development environment and CLI tool."
     href="https://f5xc-salesdemos.github.io/xcsh/"


### PR DESCRIPTION
## Summary

- Remove the Oh My XCSh `<LinkCard>` from the docs homepage (`docs/index.mdx`)
- The oh-my-xcsh repository was renamed and is no longer a standalone project in the f5xc-salesdemos ecosystem

Closes #238

## Test plan

- [ ] CI checks pass
- [ ] Docs homepage renders correctly without the removed LinkCard
- [ ] No broken references to oh-my-xcsh remain