### PR TITLE
chore: sync managed files from docs-control (#276)

### DIFF
--- a/.checkov.yaml
+++ b/.checkov.yaml
@@ -1,4 +1,29 @@
 ---
+# ── Path exclusions ──────────────────────────────────────────────────────────
+# Directories that never contain IaC. Avoids parsing large generated/vendored
+# files that cause memory exhaustion (e.g. 88 MB of OpenAPI spec JSON).
+skip-path:
+  - dist
+  - build
+  - release
+  - vendor
+  - node_modules
+  - docs/specifications
+  - specs/discovered
+  - specs/raw
+
+# ── Framework restriction ────────────────────────────────────────────────────
+# Only run frameworks relevant to this org's repos. Eliminates ~35 frameworks
+# that parse every file looking for CloudFormation/ARM/Kubernetes/etc. patterns
+# in repos that contain none of those.
+framework:
+  - github_actions
+  - github_configuration
+  - secrets
+  - terraform
+
+# ── Check exclusions ─────────────────────────────────────────────────────────
 skip-check:
-  - CKV_GHA_7
-  - CKV2_GHA_1
+  - CKV_GHA_7    # GitHub Actions — allow pinning to branch refs
+  - CKV2_GHA_1   # GitHub Actions — immutable actions (covered by Dependabot)
+  - "CKV_SECRET_4:.*specifications/api/.*\\.json$"

--- a/.claude/governance.json
+++ b/.claude/governance.json
@@ -29,6 +29,13 @@
     "zizmor.yaml",
     ".shellcheckrc",
     ".codespellrc",
+    ".prettierignore",
+    ".trivyignore",
+    "ruff.toml",
+    ".ruff.toml",
+    ".isort.cfg",
+    ".python-lint",
+    ".mypy.ini",
     ".claude/settings.json",
     ".claude/governance.json",
     ".claude/hooks/protect-managed-files.sh"

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,3 +1,3 @@
 [codespell]
-skip = *.json,*/tools/generated/*,vendor/*
-ignore-words-list = aks,datas,hcl,iterm,uncomplete,ves
+skip = *.json,*.lock,*/tools/generated/*,vendor/*
+ignore-words-list = afterall,aks,datas,edn,hcl,ists,iterm,nd,observ,pre-select,pre-selected,pre-selects,preceeding,uncomplete,ves

--- a/.editorconfig
+++ b/.editorconfig
@@ -15,5 +15,8 @@ indent_size = unset
 [*.mdx]
 indent_size = unset
 
+[*.py]
+indent_size = 4
+
 [Makefile]
 indent_style = tab

--- a/.editorconfig-checker.json
+++ b/.editorconfig-checker.json
@@ -1,4 +1,7 @@
 {
-  "Exclude": ["\\.md$", "\\.mdx$"],
-  "DisableIndentSize": true
+  "Disable": {
+    "IndentSize": true,
+    "Indentation": true
+  },
+  "Exclude": ["[.]md$", "[.]mdx$"]
 }

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Fetch Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v3
+        uses: dependabot/fetch-metadata@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Approve PR

--- a/.gitignore
+++ b/.gitignore
@@ -89,10 +89,10 @@ reports/
 projects/
 
 # Tool-specific
-.claude/settings.json
 .claude/settings.local.json
 .claude/todos/
 .claude/worktrees/
+.claude/scheduled_tasks.lock
 .playwright-mcp/
 .serena/
 .auto-claude/
@@ -100,6 +100,38 @@ claudedocs/
 cache/
 src/generated/
 out/
+
+# Bun
+*.bun-build
+
+# OpenCode plugin
+.sisyphus/*
+!.sisyphus/rules/
+packages/*/bin/
+test-injection/
+notepad.md
+oauth-success.html
+.omx/
+
+# Lock file preferences (Bun-based repos)
+package-lock.json
+yarn.lock
+
+# Monorepo build
+.turbo/
+ts-dist/
+target/
+.sst/
+tsconfig.tsbuildinfo
+
+# Nix
+.direnv/
+/result
+
+# Workspace
+.worktrees/
+.codex/
+playground/
 
 # Documentation build artifacts
 docs/_data/

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,4 @@
+[settings]
+profile = black
+force_sort_within_sections = False
+combine_as_imports = True

--- a/.jscpd.json
+++ b/.jscpd.json
@@ -7,6 +7,7 @@
     "**/node_modules/**",
     "**/dist/**",
     "**/build/**",
+    "**/release/**",
     "**/.git/**",
     "**/vendor/**",
     "**/internal/client/**",

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -1,0 +1,10 @@
+[mypy]
+python_version = 3.11
+ignore_missing_imports = True
+check_untyped_defs = True
+warn_return_any = False
+disallow_untyped_defs = False
+disallow_untyped_calls = False
+show_error_codes = True
+warn_unused_ignores = True
+no_implicit_reexport = False

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -74,7 +74,8 @@ repos:
 
   # ===========================================================================
   # Shell script analysis — config: .shellcheckrc (SC2016 disabled there)
-  # Replaces: shellcheck in super-linter (was passing SHELLCHECK_OPTS="-e SC2016")
+  # Replaces: shellcheck in super-linter
+  # (was passing SHELLCHECK_OPTS="-e SC2016")
   # ===========================================================================
   - repo: local
     hooks:
@@ -154,7 +155,7 @@ repos:
     hooks:
       - id: zizmor
         name: GitHub Actions security
-        entry: zizmor --config zizmor.yaml
+        entry: zizmor --config zizmor.yaml .github/workflows/
         language: system
         files: ^\.github/workflows/.*\.ya?ml$
         pass_filenames: false
@@ -187,8 +188,9 @@ repos:
 ci:
   autofix_prs: true
   autoupdate_schedule: weekly
-  # All language: system hooks require tools installed in the runner —
-  # skip them in pre-commit.ci (cloud) since the environment lacks these binaries.
+  # All language: system hooks require tools installed
+  # in the runner — skip them in pre-commit.ci (cloud)
+  # since the environment lacks these binaries.
   # They run locally and in GitHub Actions CI where tools are pre-installed.
   skip:
     - local-hooks

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,13 @@
+# Auto-generated files -- do not reformat
+**/src/gen/
+**/src/v2/gen/
+**/src/generated/
+**/*.gen.ts
+**/*.gen.js
+**/*.gen.d.ts
+
+# Build and release output
+dist/
+build/
+release/
+vendor/

--- a/.python-lint
+++ b/.python-lint
@@ -1,0 +1,51 @@
+[MAIN]
+py-version = 3.11
+jobs = 0
+
+[FORMAT]
+max-line-length = 88
+indent-string = '    '
+expected-line-ending-format = LF
+
+[DESIGN]
+max-args = 7
+max-branches = 15
+max-locals = 20
+max-returns = 6
+max-statements = 60
+max-attributes = 10
+max-public-methods = 25
+min-public-methods = 0
+
+[MESSAGES CONTROL]
+disable =
+    C0114,
+    C0115,
+    C0116,
+    C0206,
+    C0301,
+    C0303,
+    C0411,
+    C0413,
+    E0401,
+    E1101,
+    R0801,
+    R0903,
+    R0917,
+    R1702,
+    W0511,
+    W0611,
+    W0612,
+    W0613,
+    W0621,
+    W0622,
+    W1514
+
+[BASIC]
+good-names = i, j, k, ex, _, id, pk, db, fn, ip, ok, df
+
+[SIMILARITIES]
+min-similarity-lines = 10
+ignore-comments = yes
+ignore-docstrings = yes
+ignore-imports = yes

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,0 +1,74 @@
+extend = "pyproject.toml"
+line-length = 88
+
+[format]
+quote-style = "double"
+indent-style = "space"
+
+[lint]
+extend-select = [
+    "E", "W", "F", "I", "UP", "B", "C4", "SIM", "RUF", "PERF", "FURB",
+    "S", "TRY", "RSE", "EM", "N", "A", "Q", "COM", "RET", "ARG", "PTH",
+    "T20", "LOG", "G", "TCH", "ANN", "PT", "D", "ERA",
+    "PLC", "PLE", "PLR", "PLW",
+    "PIE", "ISC", "ICN", "PGH", "FLY", "SLF", "TD", "FIX",
+    "YTT", "DTZ", "EXE", "FA", "INT", "INP",
+]
+ignore = [
+    "E501",
+    "COM812",
+    "ISC001",
+    "D100",
+    "D104",
+    "D203",
+    "D213",
+    "ANN401",
+    "TD002",
+    "TD003",
+    "FIX002",
+    "PLR0913",
+    "PLR0912",
+    "PLR0915",
+    "ARG002",
+]
+
+[lint.per-file-ignores]
+"tests/**" = [
+    "S101",
+    "SLF001",
+    "ARG001",
+    "ARG002",
+    "ANN",
+    "D",
+    "PLR2004",
+    "TCH",
+]
+"**/conftest.py" = [
+    "ARG001",
+    "ARG002",
+    "ANN",
+    "D",
+]
+"**/__init__.py" = [
+    "F401",
+    "D104",
+]
+"scripts/**" = [
+    "T201",
+    "INP001",
+]
+
+[lint.isort]
+split-on-trailing-comma = true
+combine-as-imports = true
+
+[lint.pydocstyle]
+convention = "google"
+
+[lint.pylint]
+max-args = 7
+max-returns = 6
+max-branches = 15
+
+[lint.mccabe]
+max-complexity = 15

--- a/.textlintrc
+++ b/.textlintrc
@@ -5,7 +5,9 @@
       "exclude": [
         "repo\\b",
         "bug[- ]fix(es)?",
-        "build system(s)?"
+        "build system(s)?",
+        "readme(s)?",
+        "to-?do(s)?(?=[ ,.])"
       ]
     }
   }

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,15 @@
+# Governance-managed Trivy ignore list
+# Review quarterly — remove entries when upstream fixes are released
+#
+# Format: one CVE/ID per line
+# Lines starting with # are comments
+
+# CVE-2026-4539 — Low severity (CVSS 3.3) ReDoS in pygments AdlLexer
+# Transitive dependency: rich -> pygments
+# Affected: pygments <= 2.19.2 — no fix released to PyPI
+# Fix merged upstream: pygments/pygments#3064 (2026-03-25)
+# Pygments maintainers dispute this as a security issue per their security policy
+# Impact: Zero — AdlLexer handles openEHR archetype definitions, unused in this context
+# Expiry: 2026-05-31 — re-evaluate after pygments releases fix
+# Ref: https://nvd.nist.gov/vuln/detail/CVE-2026-4539
+CVE-2026-4539

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -6,6 +6,11 @@ ignore: |
   docs/specifications/
 rules:
   line-length: disable
+  brackets:
+    min-spaces-inside: 0
+    max-spaces-inside: 0
+    min-spaces-inside-empty: 0
+    max-spaces-inside-empty: 0
   truthy:
     allowed-values: ["true", "false", "on"]
   comments:

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.3.14/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.10/schema.json",
   "formatter": {
     "indentStyle": "space",
     "indentWidth": 2,
@@ -26,6 +26,15 @@
     "includes": ["**", "!packages/*/icons.json"]
   },
   "overrides": [
+    {
+      "includes": ["dist/**", "build/**", "release/**", "vendor/**"],
+      "formatter": {
+        "enabled": false
+      },
+      "linter": {
+        "enabled": false
+      }
+    },
     {
       "includes": ["**/*.astro"],
       "linter": {

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,74 @@
+extend = "pyproject.toml"
+line-length = 88
+
+[format]
+quote-style = "double"
+indent-style = "space"
+
+[lint]
+extend-select = [
+    "E", "W", "F", "I", "UP", "B", "C4", "SIM", "RUF", "PERF", "FURB",
+    "S", "TRY", "RSE", "EM", "N", "A", "Q", "COM", "RET", "ARG", "PTH",
+    "T20", "LOG", "G", "TCH", "ANN", "PT", "D", "ERA",
+    "PLC", "PLE", "PLR", "PLW",
+    "PIE", "ISC", "ICN", "PGH", "FLY", "SLF", "TD", "FIX",
+    "YTT", "DTZ", "EXE", "FA", "INT", "INP",
+]
+ignore = [
+    "E501",
+    "COM812",
+    "ISC001",
+    "D100",
+    "D104",
+    "D203",
+    "D213",
+    "ANN401",
+    "TD002",
+    "TD003",
+    "FIX002",
+    "PLR0913",
+    "PLR0912",
+    "PLR0915",
+    "ARG002",
+]
+
+[lint.per-file-ignores]
+"tests/**" = [
+    "S101",
+    "SLF001",
+    "ARG001",
+    "ARG002",
+    "ANN",
+    "D",
+    "PLR2004",
+    "TCH",
+]
+"**/conftest.py" = [
+    "ARG001",
+    "ARG002",
+    "ANN",
+    "D",
+]
+"**/__init__.py" = [
+    "F401",
+    "D104",
+]
+"scripts/**" = [
+    "T201",
+    "INP001",
+]
+
+[lint.isort]
+split-on-trailing-comma = true
+combine-as-imports = true
+
+[lint.pydocstyle]
+convention = "google"
+
+[lint.pylint]
+max-args = 7
+max-returns = 6
+max-branches = 15
+
+[lint.mccabe]
+max-complexity = 15

--- a/zizmor.yaml
+++ b/zizmor.yaml
@@ -46,3 +46,9 @@ rules:
   # for reusable workflows
   secrets-inherit:
     disable: true
+  # Governance workflows intentionally use
+  # secrets without dedicated environments;
+  # environment-based access control is not
+  # needed for org-internal automation tokens
+  secrets-outside-env:
+    disable: true


### PR DESCRIPTION
## Summary
Sync the 20 managed files listed in #276 with the canonical versions in `f5xc-salesdemos/docs-control`. No local edits — contents are taken verbatim from the governance template.

Closes #276
Closes #175

## Test plan
- [ ] `check / Check linked issues` passes
- [ ] `lint / Lint Code Base` passes (known advisory-only per branch protection)