### PR TITLE
chore: remove api-mcp and terraform-provider-mcp from landing page and federation

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -167,12 +167,6 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
 <CardGrid>
   <LinkCard
     icon="f5xc:ai_assistant_logo"
-    title="API MCP"
-    description="MCP server for F5 Distributed Cloud API."
-    href="https://f5xc-salesdemos.github.io/api-mcp/"
-  />
-  <LinkCard
-    icon="f5xc:ai_assistant_logo"
     title="Marketplace"
     description="AI-powered marketplace for F5 Distributed Cloud solutions."
     href="https://f5xc-salesdemos.github.io/marketplace/"

--- a/docs/llms-federated-sites.json
+++ b/docs/llms-federated-sites.json
@@ -75,11 +75,6 @@
     "description": "F5 XC API security"
   },
   {
-    "label": "API MCP",
-    "url": "https://f5xc-salesdemos.github.io/api-mcp/llms.txt",
-    "description": "MCP server for F5 Distributed Cloud API"
-  },
-  {
     "label": "API Specs",
     "url": "https://f5xc-salesdemos.github.io/api-specs/llms.txt",
     "description": "OpenAPI spec validation and reconciliation for F5 Distributed Cloud"
@@ -108,11 +103,6 @@
     "label": "Dev Container",
     "url": "https://f5xc-salesdemos.github.io/devcontainer/llms.txt",
     "description": "Isolated development environment with AI coding tools"
-  },
-  {
-    "label": "Terraform Provider MCP",
-    "url": "https://f5xc-salesdemos.github.io/terraform-provider-mcp/llms.txt",
-    "description": "MCP server exposing Terraform provider schemas"
   },
   {
     "label": "Marketplace",


### PR DESCRIPTION
## Summary

- `docs/llms-federated-sites.json` — drop both `api-mcp` and `terraform-provider-mcp` entries. 25 → 23 entries.
- `docs/index.mdx` — remove the "API MCP" LinkCard from the AI CardGrid. (`terraform-provider-mcp` has no LinkCard on this page.)

Part of the MCP decommission. Both repos have been archived (read-only) as of 2026-04-22.

## Verification

- JSON syntax validated with `jq empty`.
- Grep for `api-mcp` and `terraform-provider-mcp` in `docs/`: zero matches after edit.
- Diff: 16 deletions, 0 insertions.

Closes #320

See also the master tracking issue at f5xc-salesdemos/docs-control#393.