### PR TITLE
feat: add cdn-simulator to landing page and LLM federation

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -74,6 +74,12 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     href="https://f5xc-salesdemos.github.io/cdn/"
   />
   <LinkCard
+    icon="f5xc:content-delivery-network"
+    title="CDN Simulator"
+    description="NGINX-based CDN edge node simulator for multi-vendor lab environments."
+    href="https://f5xc-salesdemos.github.io/cdn-simulator/"
+  />
+  <LinkCard
     icon="f5xc:dns-management"
     title="DNS"
     description="DNS management, zones, and load balancing."

--- a/docs/llms-federated-sites.json
+++ b/docs/llms-federated-sites.json
@@ -113,5 +113,10 @@
     "label": "XCSh",
     "url": "https://f5xc-salesdemos.github.io/xcsh/llms.txt",
     "description": "AI-powered development environment and CLI tool"
+  },
+  {
+    "label": "CDN Simulator",
+    "url": "https://f5xc-salesdemos.github.io/cdn-simulator/llms.txt",
+    "description": "NGINX-based CDN edge node simulator for multi-vendor lab environments"
   }
 ]


### PR DESCRIPTION
## Summary

- Add CDN Simulator LinkCard to the landing page under "Networking & Performance" section, placed after the existing CDN card
- Add CDN Simulator entry to `llms-federated-sites.json` for LLM federation catalog discoverability

Closes #334

## Test plan

- [ ] CI checks pass
- [ ] Landing page renders the new CDN Simulator card correctly at https://f5xc-salesdemos.github.io/docs/
- [ ] LLM federation JSON remains valid and parseable