### PR TITLE
feat: add Origin Server to landing page and LLM federation

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -80,6 +80,12 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     href="https://f5xc-salesdemos.github.io/cdn-simulator/"
   />
   <LinkCard
+    icon="f5xc:distributed-apps"
+    title="Origin Server"
+    description="Ubuntu 24.04 origin server with vulnerable web applications for F5 XC demo environments."
+    href="https://f5xc-salesdemos.github.io/origin-server/"
+  />
+  <LinkCard
     icon="f5xc:dns-management"
     title="DNS"
     description="DNS management, zones, and load balancing."

--- a/docs/llms-federated-sites.json
+++ b/docs/llms-federated-sites.json
@@ -118,5 +118,10 @@
     "label": "CDN Simulator",
     "url": "https://f5xc-salesdemos.github.io/cdn-simulator/llms.txt",
     "description": "NGINX-based CDN edge node simulator for multi-vendor lab environments"
+  },
+  {
+    "label": "Origin Server",
+    "url": "https://f5xc-salesdemos.github.io/origin-server/llms.txt",
+    "description": "Ubuntu 24.04 origin server with vulnerable web applications for F5 XC demo environments"
   }
 ]


### PR DESCRIPTION
## Summary

- Add Origin Server LinkCard to the Networking and Performance section of the docs landing page
- Add Origin Server entry to `llms-federated-sites.json` for AI assistant federated search discovery

Closes #336

## Test plan

- [ ] CI checks pass
- [ ] Landing page renders the new Origin Server LinkCard in the correct section
- [ ] LLM federation JSON is valid and includes the origin-server llms.txt URL