### PR TITLE
fix: standardize xcsh label casing to lowercase

### DIFF
--- a/docs/llms-federated-sites.json
+++ b/docs/llms-federated-sites.json
@@ -110,7 +110,7 @@
     "description": "AI-powered marketplace for F5 Distributed Cloud solutions"
   },
   {
-    "label": "XCSh",
+    "label": "xcsh",
     "url": "https://f5xc-salesdemos.github.io/xcsh/llms.txt",
     "description": "AI-powered development environment and CLI tool"
   },


### PR DESCRIPTION
## Summary

- Standardize the xcsh label in `docs/llms-federated-sites.json` from historical "XCSh" casing to the codespell-enforced lowercase "xcsh"

Closes #343

## Test plan

- [x] Pre-commit hooks pass (including codespell spelling check)
- [ ] CI checks pass
- [ ] LLM federation JSON remains valid