### PR TITLE
docs: add frontmatter description for llms.txt hierarchy

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: F5 Distributed Cloud Sales Demos
+description: Demo guides and runbooks for F5 Distributed Cloud sales engineering.
 template: splash
 hero:
   title: Sales Demos


### PR DESCRIPTION
## Summary

- Adds a `description:` field to `docs/index.mdx` frontmatter so the starlight-llms-txt plugin includes page-level metadata in the llms.txt output

Refs f5xc-salesdemos/xcsh#223

Step 5c of the cascading llms.txt knowledge hierarchy — adds a `description:` field to the index page frontmatter so the starlight-llms-txt plugin can include it in the llms.txt output.

Closes #349

## Test plan

- [ ] CI checks pass
- [ ] Verify the starlight-llms-txt plugin picks up the new description field in the generated llms.txt