### PR TITLE
feat(landing): add traffic-generator card to docs landing page

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -87,6 +87,12 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     href="https://f5xc-salesdemos.github.io/origin-server/"
   />
   <LinkCard
+    icon="f5xc:application-traffic-insight"
+    title="Traffic Generator"
+    description="Azure Ubuntu 24.04 VM with 50+ security tools and attack suites for F5 XC demo traffic generation."
+    href="https://f5xc-salesdemos.github.io/traffic-generator/"
+  />
+  <LinkCard
     icon="f5xc:dns-management"
     title="DNS"
     description="DNS management, zones, and load balancing."


### PR DESCRIPTION
## Summary

- Add Traffic Generator LinkCard to the Networking section of the docs landing page
- Uses `f5xc:application-traffic-insight` icon, positioned after Origin Server
- Completes landing page navigation for all onboarded repositories

Closes #366

## Test plan

- [ ] CI checks pass
- [ ] Traffic Generator card renders on the landing page
- [ ] Card links to https://f5xc-salesdemos.github.io/traffic-generator/