### PR TITLE
feat: add Demo Resources section to landing page and federation

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -75,24 +75,6 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     href="https://f5xc-salesdemos.github.io/cdn/"
   />
   <LinkCard
-    icon="f5xc:content-delivery-network"
-    title="CDN Simulator"
-    description="NGINX-based CDN edge node simulator for multi-vendor lab environments."
-    href="https://f5xc-salesdemos.github.io/cdn-simulator/"
-  />
-  <LinkCard
-    icon="f5xc:distributed-apps"
-    title="Origin Server"
-    description="Ubuntu 24.04 origin server with vulnerable web applications for F5 XC demo environments."
-    href="https://f5xc-salesdemos.github.io/origin-server/"
-  />
-  <LinkCard
-    icon="f5xc:application-traffic-insight"
-    title="Traffic Generator"
-    description="Azure Ubuntu 24.04 VM with 50+ security tools and attack suites for F5 XC demo traffic generation."
-    href="https://f5xc-salesdemos.github.io/traffic-generator/"
-  />
-  <LinkCard
     icon="f5xc:dns-management"
     title="DNS"
     description="DNS management, zones, and load balancing."
@@ -103,6 +85,35 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     title="NGINX"
     description="NGINX integration and configuration management."
     href="https://f5xc-salesdemos.github.io/nginx/"
+  />
+</CardGrid>
+
+## Demo Resources
+
+<CardGrid>
+  <LinkCard
+    icon="f5xc:distributed-apps"
+    title="Origin Server"
+    description="Ubuntu 24.04 VM with 9 vulnerable web applications for WAF, API, and bot defense testing."
+    href="https://f5xc-salesdemos.github.io/origin-server/"
+  />
+  <LinkCard
+    icon="f5xc:application-traffic-insight"
+    title="Traffic Generator"
+    description="Azure VM with 50+ security tools and 7 attack suites for demo traffic generation."
+    href="https://f5xc-salesdemos.github.io/traffic-generator/"
+  />
+  <LinkCard
+    icon="f5xc:content-delivery-network"
+    title="CDN Simulator"
+    description="NGINX-based CDN edge node simulator with 67+ vendor-specific headers."
+    href="https://f5xc-salesdemos.github.io/cdn-simulator/"
+  />
+  <LinkCard
+    icon="f5xc:platform"
+    title="View All Components"
+    description="Browse the full demo resource catalog."
+    href="https://f5xc-salesdemos.github.io/demo-resources/"
   />
 </CardGrid>
 

--- a/docs/llms-federated-sites.json
+++ b/docs/llms-federated-sites.json
@@ -154,5 +154,11 @@
     "url": "https://f5xc-salesdemos.github.io/traffic-generator/llms.txt",
     "description": "Azure Ubuntu 24.04 VM with 50+ security tools and attack suites for F5 XC demo traffic generation",
     "category": "lab-infrastructure"
+  },
+  {
+    "label": "Demo Resources",
+    "url": "https://f5xc-salesdemos.github.io/demo-resources/llms.txt",
+    "description": "Catalog of pre-configured Azure VM components for F5 XC demo environments",
+    "category": "lab-infrastructure"
   }
 ]


### PR DESCRIPTION
## Summary

- Adds a dedicated "Demo Resources" section to the docs landing page, grouping origin server, traffic generator, and CDN simulator under their own heading with a "View All Components" link
- Moves DNS and NGINX cards up into the Networking section for clearer categorization
- Adds the demo-resources site to `llms-federated-sites.json` with `lab-infrastructure` category for progressive LLM discovery

Closes #375

## Test plan

- [ ] CI checks pass (linked issues check, super-linter)
- [ ] Landing page renders with Networking and Demo Resources sections correctly separated
- [ ] Federation JSON is valid and includes the new demo-resources entry
- [ ] All card links resolve to their respective docs sites