### PR TITLE
feat: add VS Code Extension to llms.txt federation

### DIFF
--- a/docs/llms-federated-sites.json
+++ b/docs/llms-federated-sites.json
@@ -138,6 +138,12 @@
     "category": "developer-tools"
   },
   {
+    "label": "VS Code Extension",
+    "url": "https://f5xc-salesdemos.github.io/vscode-f5xc-tools/llms.txt",
+    "description": "VS Code extension for managing F5 Distributed Cloud resources",
+    "category": "developer-tools"
+  },
+  {
     "label": "CDN Simulator",
     "url": "https://f5xc-salesdemos.github.io/cdn-simulator/llms.txt",
     "description": "NGINX-based CDN edge node simulator for multi-vendor lab environments",


### PR DESCRIPTION
## Summary

- Add the VS Code Extension (`vscode-f5xc-tools`) to the llms.txt federated sites configuration
- The new entry uses the `developer-tools` category and points to the Starlight-generated `llms.txt` endpoint
- Enables the docs hub to aggregate VS Code extension documentation for LLM consumption

Closes #453

## Test plan

- [ ] CI checks pass (lint, JSON validation)
- [ ] Verify `docs/llms-federated-sites.json` is valid JSON with correct schema
- [ ] Confirm the new entry URL resolves once the vscode-f5xc-tools repo deploys its Starlight site