### PR TITLE
feat: add Developer Tools section to landing page

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -192,6 +192,23 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
   />
 </CardGrid>
 
+## Developer Tools
+
+<CardGrid>
+  <LinkCard
+    icon="f5xc:distributed-apps"
+    title="VS Code Extension"
+    description="Manage F5 XC resources from VS Code with IntelliSense and xcsh chat assistant."
+    href="https://f5xc-salesdemos.github.io/vscode-f5xc-tools/"
+  />
+  <LinkCard
+    icon="f5xc:ai_assistant_logo"
+    title="xcsh CLI"
+    description="AI-powered shell for F5 Distributed Cloud operations."
+    href="https://f5xc-salesdemos.github.io/xcsh/"
+  />
+</CardGrid>
+
 ## AI
 
 <CardGrid>


### PR DESCRIPTION
## Summary

- Add a new **Developer Tools** section to the organization landing page with two cards:
  - **VS Code Extension** — manage F5 XC resources from VS Code with IntelliSense and xcsh chat assistant
  - **xcsh CLI** — AI-powered shell for F5 Distributed Cloud operations

Closes #479

## Test plan

- [ ] CI checks pass
- [ ] Landing page renders correctly with new Developer Tools section
- [ ] VS Code Extension card links to https://f5xc-salesdemos.github.io/vscode-f5xc-tools/
- [ ] xcsh CLI card links to https://f5xc-salesdemos.github.io/xcsh/