### PR TITLE
chore: sync managed files from governance template

### DIFF
--- a/.checkov.yaml
+++ b/.checkov.yaml
@@ -38,6 +38,8 @@ skip-check:
   - CKV_GHA_5    # GitHub Actions — cosign signing not required for this org
   - CKV_GHA_6    # GitHub Actions — cosign SBOM attestation not required
   - "CKV_SECRET_4:.*specifications/api/.*\\.json$"
+  - CKV_SECRET_2    # False positive — test fixtures and example values
+  - CKV_SECRET_6    # False positive — high entropy strings in provider schemas
   - CKV_AZURE_1    # Lab VM — SSH key auth configured via cloud-init
   - CKV_AZURE_9    # Lab NSG — RDP not used, SSH only
   - CKV_AZURE_10   # Lab NSG — SSH open for demo access

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,3 +1,3 @@
 [codespell]
-skip = *.json,*.lock,*/tools/generated/*,vendor/*,*/vendored/*,*-vendored*,*/fixtures/*,*.min.js,*.jsonl,*.b64.js,*/gen/*,node_modules,target,dist,.git,packages/*/dist,crates/*/vendored
-ignore-words-list = afterall,aks,anull,datas,deliverys,edn,hcl,ists,iterm,nd,nin,observ,pre-select,pre-selected,pre-selects,preceeding,uncomplete,ves,doesnt,forin,statics,ser,anc,abd,fo,te,runn,crossreferences,prevend,aline,invokable,takin,hel,unparseable,defaul,doub,cros,deine
+skip = *.json,*.lock,*/tools/generated/*,vendor/*,*/vendored/*,*-vendored*,*/fixtures/*,*.min.js,*.jsonl,*.b64.js,*/gen/*,node_modules,target,dist,.git,packages/*/dist,crates/*/vendored,*.generated.ts
+ignore-words-list = afterall,aks,anull,datas,deliverys,edn,hcl,ists,iterm,nd,nin,observ,pre-select,pre-selected,pre-selects,preceeding,uncomplete,ves,doesnt,forin,statics,ser,anc,abd,fo,te,runn,crossreferences,prevend,aline,invokable,takin,hel,unparseable,defaul,doub,cros,deine,dentify,opps,pecified,atmost,atleast

--- a/.github/workflows/enforce-repo-settings.yml
+++ b/.github/workflows/enforce-repo-settings.yml
@@ -30,6 +30,9 @@ jobs:
       source_sha: ${{ inputs.source_sha || '' }}
     secrets:
       repo-settings-token: ${{ secrets.REPO_SETTINGS_TOKEN }}
+      ORG_NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      ORG_RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+      ORG_REPO_SYNC_TOKEN: ${{ secrets.REPO_SYNC_TOKEN }}
 
   sync-files:
     uses: f5xc-salesdemos/docs-control/.github/workflows/sync-managed-files.yml@main

--- a/.gitignore
+++ b/.gitignore
@@ -146,6 +146,20 @@ docs/api-reference/
 .etag
 .github_release
 
+# Autoresearch session artifacts
+autoresearch.sh
+autoresearch.md
+autoresearch.program.md
+autoresearch.checks.sh
+autoresearch-loop.sh
+autoresearch.ideas.md
+autoresearch-queries.txt
+autoresearch.jsonl
+.autoresearch/
+
+# Session-resume files
+handoff.md
+
 # Union from xcsh fork (promoted 2026-04-19)
 .npm/
 packages/*/dist/

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.12/schema.json",
   "formatter": {
     "indentStyle": "space",
     "indentWidth": 2,
@@ -36,7 +35,7 @@
       }
     },
     {
-      "includes": ["docs/specifications/api/**", "docs/api-reference/**"],
+      "includes": ["docs/specifications/api/**", "docs/api-reference/**", "tools/**"],
       "formatter": {
         "enabled": false
       }


### PR DESCRIPTION
Closes #483

Synced managed files from `f5xc-salesdemos/docs-control` canonical source:

- .github/workflows/enforce-repo-settings.yml
- .gitignore
- biome.json
- .checkov.yaml
- .codespellrc