### PR TITLE
i18n: re-translate all locales with glossary-enforced product terms

### DIFF
--- a/docs/ar/index.mdx
+++ b/docs/ar/index.mdx
@@ -1,10 +1,10 @@
 ---
-title: عروض مبيعات F5 Distributed Cloud التوضيحية
-description: أدلة العروض التوضيحية وكتب التشغيل لهندسة مبيعات F5 Distributed Cloud.
+title: عروض مبيعات F5 Distributed Cloud
+description: أدلة العرض التوضيحي وكتيبات التشغيل لهندسة مبيعات F5 Distributed Cloud.
 template: splash
 hero:
-  title: العروض التوضيحية للمبيعات
-  tagline: أدلة العروض التوضيحية وكتب التشغيل لهندسة مبيعات F5 Distributed Cloud.
+  title: عروض المبيعات
+  tagline: أدلة العرض التوضيحي وكتيبات التشغيل لهندسة مبيعات F5 Distributed Cloud.
   image:
     html: >-
       <img src="/docs/images/hero-platform.svg" alt="F5 Distributed Cloud
@@ -23,37 +23,37 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
   <LinkCard
     icon="f5xc:web-app-and-api-protection"
     title="WAF"
-    description="تكوين جدار حماية تطبيقات الويب والسياسات."
+    description="إعداد جدار حماية تطبيقات الويب (WAF) وسياساته."
     href="https://f5xc-salesdemos.github.io/waf/"
   />
   <LinkCard
     icon="f5xc:web-app-and-api-protection"
     title="API"
-    description="اكتشاف واجهات برمجة التطبيقات وحمايتها وسياسات الأمان."
+    description="اكتشاف API وحمايته وسياسات الأمان."
     href="https://f5xc-salesdemos.github.io/api-protection/"
   />
   <LinkCard
     icon="f5xc:bot-defense"
-    title="الحماية المتقدمة من الروبوتات"
-    description="حماية متقدمة من الروبوتات مع التحليل السلوكي."
+    title="Bot Advanced"
+    description="دفاع Bot المتقدم مع التحليل السلوكي."
     href="https://f5xc-salesdemos.github.io/bot-advanced/"
   />
   <LinkCard
     icon="f5xc:bot-defense"
-    title="الحماية القياسية من الروبوتات"
-    description="حماية قياسية من الروبوتات مع الكشف القائم على التوقيعات."
+    title="Bot Standard"
+    description="دفاع Bot القياسي مع الكشف المبني على التوقيعات."
     href="https://f5xc-salesdemos.github.io/bot-standard/"
   />
   <LinkCard
     icon="f5xc:client-side-defense"
     title="CSD"
-    description="الحماية من جانب العميل ضد تهديدات المتصفح."
+    description="الدفاع من جهة العميل ضد التهديدات المستندة إلى المتصفح."
     href="https://f5xc-salesdemos.github.io/csd/"
   />
   <LinkCard
     icon="f5xc:ddos-and-transit-services"
     title="DDoS"
-    description="الحماية من هجمات حجب الخدمة الموزعة."
+    description="حماية DDoS من هجمات الحرمان من الخدمة الموزعة."
     href="https://f5xc-salesdemos.github.io/ddos/"
   />
   <LinkCard
@@ -70,7 +70,7 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
   <LinkCard
     icon="f5xc:multi-cloud-network-connect"
     title="MCN"
-    description="الشبكات متعددة السحابات والاتصال بين المواقع."
+    description="الشبكات متعددة السحابات واتصال المواقع."
     href="https://f5xc-salesdemos.github.io/mcn/"
   />
   <LinkCard
@@ -82,42 +82,42 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
   <LinkCard
     icon="f5xc:dns-management"
     title="DNS"
-    description="إدارة DNS والمناطق وموازنة الأحمال."
+    description="إدارة DNS والمناطق وموازنة تحميل DNS."
     href="https://f5xc-salesdemos.github.io/dns/"
   />
   <LinkCard
     icon="f5xc:nginx-one"
     title="NGINX"
-    description="تكامل NGINX وإدارة التكوين."
+    description="تكامل NGINX وإدارة الإعدادات."
     href="https://f5xc-salesdemos.github.io/nginx/"
   />
 </CardGrid>
 
-## موارد العروض التوضيحية
+## موارد العرض التوضيحي
 
 <CardGrid>
   <LinkCard
     icon="f5xc:distributed-apps"
     title="خادم المصدر"
-    description="جهاز افتراضي Ubuntu 24.04 يحتوي على 9 تطبيقات ويب معرضة للثغرات لاختبار WAF وAPI والحماية من الروبوتات."
+    description="جهاز VM يعمل بنظام Ubuntu 24.04 مع 9 تطبيقات ويب قابلة للاختراق لاختبار جدار حماية تطبيقات الويب (WAF) وأمان API ودفاع Bot."
     href="https://f5xc-salesdemos.github.io/origin-server/"
   />
   <LinkCard
     icon="f5xc:application-traffic-insight"
-    title="مولّد حركة المرور"
-    description="جهاز افتراضي Azure يحتوي على أكثر من 50 أداة أمنية و7 مجموعات هجوم لتوليد حركة مرور العروض التوضيحية."
+    title="مولد حركة المرور"
+    description="جهاز VM على Azure مع أكثر من 50 أداة أمان و7 حزم هجوم لتوليد حركة مرور العرض التوضيحي."
     href="https://f5xc-salesdemos.github.io/traffic-generator/"
   />
   <LinkCard
     icon="f5xc:content-delivery-network"
     title="محاكي CDN"
-    description="محاكي عقدة حافة CDN مبني على NGINX مع أكثر من 67 ترويسة خاصة بالمورّدين."
+    description="محاكي عقدة حافة CDN مبني على NGINX مع أكثر من 67 رأسًا خاصًا بالموردين."
     href="https://f5xc-salesdemos.github.io/cdn-simulator/"
   />
   <LinkCard
     icon="f5xc:platform"
     title="عرض جميع المكونات"
-    description="تصفح كتالوج موارد العروض التوضيحية الكامل."
+    description="تصفح كتالوج موارد العرض التوضيحي الكامل."
     href="https://f5xc-salesdemos.github.io/demo-resources/"
   />
 </CardGrid>
@@ -127,14 +127,14 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
 <CardGrid>
   <LinkCard
     icon="f5xc:observability"
-    title="المراقبة"
-    description="الرصد والمقاييس ورؤى التطبيقات."
+    title="قابلية المراقبة"
+    description="المراقبة والمقاييس ورؤى التطبيقات."
     href="https://f5xc-salesdemos.github.io/observability/"
   />
   <LinkCard
     icon="f5xc:administration"
     title="الإدارة"
-    description="إدارة المستأجرين والتحكم في الوصول المبني على الأدوار وإعدادات المنصة."
+    description="إدارة المستأجرين وصلاحيات RBAC وإعدادات المنصة."
     href="https://f5xc-salesdemos.github.io/administration/"
   />
 </CardGrid>
@@ -144,20 +144,20 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
 <CardGrid>
   <LinkCard
     icon="hashicorp-flight:terraform-color"
-    title="مزوّد Terraform"
-    description="مزوّد Terraform لـ F5 Distributed Cloud."
+    title="موفر Terraform"
+    description="موفر Terraform لـ F5 Distributed Cloud."
     href="https://f5xc-salesdemos.github.io/terraform-provider-f5xc/"
   />
   <LinkCard
     icon="f5xc:data-intelligence"
     title="مواصفات API"
-    description="التحقق من مواصفات OpenAPI ومطابقتها لـ F5 Distributed Cloud."
+    description="التحقق من صحة مواصفات OpenAPI والتوفيق بينها لـ F5 Distributed Cloud."
     href="https://f5xc-salesdemos.github.io/api-specs/"
   />
   <LinkCard
     icon="f5xc:data-intelligence"
-    title="مواصفات API المُثرية"
-    description="مواصفات OpenAPI مُثرية لـ F5 Distributed Cloud."
+    title="مواصفات API المحسّنة"
+    description="مواصفات OpenAPI المحسّنة لـ F5 Distributed Cloud."
     href="https://f5xc-salesdemos.github.io/api-specs-enriched/"
   />
 </CardGrid>
@@ -167,26 +167,26 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
 <CardGrid>
   <LinkCard
     icon="f5xc:doc"
-    title="المُنشئ"
-    description="نظام بناء توثيق حاوي مبني على Astro + Starlight."
+    title="Builder"
+    description="نظام بناء توثيق Astro + Starlight المعبّأ في حاويات."
     href="https://f5xc-salesdemos.github.io/docs-builder/"
   />
   <LinkCard
     icon="f5xc:shared-configuration"
-    title="القالب"
-    description="هوية بصرية وتنسيق مشترك لمواقع التوثيق."
+    title="Theme"
+    description="العلامة التجارية المشتركة والتنسيق لمواقع التوثيق."
     href="https://f5xc-salesdemos.github.io/docs-theme/"
   />
   <LinkCard
     icon="f5xc:distributed-apps"
-    title="الأيقونات"
-    description="حزم أيقونات NPM وإضافات لنظام بناء التوثيق."
+    title="Icons"
+    description="حزم أيقونات NPM والمكونات الإضافية لنظام بناء التوثيق."
     href="https://f5xc-salesdemos.github.io/docs-icons/"
   />
   <LinkCard
     icon="f5xc:shared-configuration"
-    title="التحكم"
-    description="سير عمل CI وقوالب الحوكمة وتطبيق إعدادات المستودعات."
+    title="Control"
+    description="سير عمل CI وقوالب الحوكمة وتطبيق إعدادات المستودع."
     href="https://f5xc-salesdemos.github.io/docs-control/"
   />
   <LinkCard
@@ -208,7 +208,7 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
   />
   <LinkCard
     icon="f5xc:ai_assistant_logo"
-    title="واجهة سطر أوامر xcsh"
+    title="xcsh CLI"
     description="واجهة سطر أوامر مدعومة بالذكاء الاصطناعي لعمليات F5 Distributed Cloud."
     href="https://f5xc-salesdemos.github.io/xcsh/"
   />
@@ -220,7 +220,7 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
   <LinkCard
     icon="f5xc:ai_assistant_logo"
     title="السوق"
-    description="سوق مدعوم بالذكاء الاصطناعي لحلول F5 Distributed Cloud."
+    description="السوق المدعوم بالذكاء الاصطناعي لحلول F5 Distributed Cloud."
     href="https://f5xc-salesdemos.github.io/marketplace/"
   />
 </CardGrid>

--- a/docs/de/index.mdx
+++ b/docs/de/index.mdx
@@ -1,14 +1,10 @@
 ---
-title: F5 Distributed Cloud Vertriebsdemos
-description: >-
-  Demo-Leitfäden und Runbooks für das Sales Engineering von F5 Distributed
-  Cloud.
+title: F5 Distributed Cloud Sales Demos
+description: Demo-Leitfäden und Runbooks für das F5 Distributed Cloud Sales Engineering.
 template: splash
 hero:
-  title: Vertriebsdemos
-  tagline: >-
-    Demo-Leitfäden und Runbooks für das Sales Engineering von F5 Distributed
-    Cloud.
+  title: Sales Demos
+  tagline: Demo-Leitfäden und Runbooks für das F5 Distributed Cloud Sales Engineering.
   image:
     html: >-
       <img src="/docs/images/hero-platform.svg" alt="F5 Distributed Cloud
@@ -27,66 +23,66 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
   <LinkCard
     icon="f5xc:web-app-and-api-protection"
     title="WAF"
-    description="Konfiguration und Richtlinien für Web Application Firewalls."
+    description="Konfiguration und Richtlinien für die Web-App-Firewall (WAF)."
     href="https://f5xc-salesdemos.github.io/waf/"
   />
   <LinkCard
     icon="f5xc:web-app-and-api-protection"
     title="API"
-    description="API-Erkennung, Schutz und Sicherheitsrichtlinien."
+    description="API-Erkennung, -Schutz und Sicherheitsrichtlinien."
     href="https://f5xc-salesdemos.github.io/api-protection/"
   />
   <LinkCard
     icon="f5xc:bot-defense"
     title="Bot Advanced"
-    description="Erweiterte Bot-Abwehr mit Verhaltensanalyse."
+    description="Bot-Abwehr erweitert mit Verhaltensanalyse."
     href="https://f5xc-salesdemos.github.io/bot-advanced/"
   />
   <LinkCard
     icon="f5xc:bot-defense"
     title="Bot Standard"
-    description="Standard-Bot-Abwehr mit signaturbasierter Erkennung."
+    description="Bot-Abwehr Standard mit signaturbasierter Erkennung."
     href="https://f5xc-salesdemos.github.io/bot-standard/"
   />
   <LinkCard
     icon="f5xc:client-side-defense"
     title="CSD"
-    description="Client-seitiger Schutz gegen browserbasierte Bedrohungen."
+    description="Clientseitige Abwehr gegen browserbasierte Bedrohungen."
     href="https://f5xc-salesdemos.github.io/csd/"
   />
   <LinkCard
     icon="f5xc:ddos-and-transit-services"
     title="DDoS"
-    description="Schutz vor verteilten Denial-of-Service-Angriffen."
+    description="DDoS-Schutz gegen verteilte Denial-of-Service-Angriffe."
     href="https://f5xc-salesdemos.github.io/ddos/"
   />
   <LinkCard
     icon="f5xc:web-app-scanning"
     title="WAS"
-    description="Web-Application-Scanning und Schwachstellenbewertung."
+    description="Web-App-Scanning und Schwachstellenbewertung."
     href="https://f5xc-salesdemos.github.io/was/"
   />
 </CardGrid>
 
-## Netzwerk &amp; Performance
+## Netzwerk &amp; Leistung
 
 <CardGrid>
   <LinkCard
     icon="f5xc:multi-cloud-network-connect"
     title="MCN"
-    description="Multi-Cloud-Netzwerk und Standortverbindung."
+    description="Multi-Cloud-Netzwerk und Site-Konnektivität."
     href="https://f5xc-salesdemos.github.io/mcn/"
   />
   <LinkCard
     icon="f5xc:content-delivery-network"
     title="CDN"
-    description="Content Delivery Network und Edge-Caching."
+    description="Inhaltsbereitstellung und Edge-Caching."
     href="https://f5xc-salesdemos.github.io/cdn/"
   />
   <LinkCard
     icon="f5xc:dns-management"
     title="DNS"
-    description="DNS-Verwaltung, Zonen und Lastverteilung."
+    description="DNS-Verwaltung, Zonen und DNS-Lastverteilung."
     href="https://f5xc-salesdemos.github.io/dns/"
   />
   <LinkCard
@@ -102,26 +98,26 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
 <CardGrid>
   <LinkCard
     icon="f5xc:distributed-apps"
-    title="Origin-Server"
-    description="Ubuntu 24.04 VM mit 9 verwundbaren Webanwendungen für WAF-, API- und Bot-Abwehr-Tests."
+    title="Ursprungsserver"
+    description="Ubuntu 24.04 VM mit 9 verwundbaren Webanwendungen für WAF-, API- und Bot-Abwehrtests."
     href="https://f5xc-salesdemos.github.io/origin-server/"
   />
   <LinkCard
     icon="f5xc:application-traffic-insight"
-    title="Traffic-Generator"
-    description="Azure VM mit über 50 Sicherheitstools und 7 Angriffs-Suites zur Demo-Traffic-Generierung."
+    title="Datenverkehrsgenerator"
+    description="Azure VM mit 50+ Sicherheitswerkzeugen und 7 Angriffs-Suites zur Demo-Datenverkehrserzeugung."
     href="https://f5xc-salesdemos.github.io/traffic-generator/"
   />
   <LinkCard
     icon="f5xc:content-delivery-network"
     title="CDN-Simulator"
-    description="NGINX-basierter CDN-Edge-Node-Simulator mit über 67 anbieterspezifischen Headern."
+    description="NGINX-basierter CDN-Edge-Node-Simulator mit 67+ anbieterspezifischen Headern."
     href="https://f5xc-salesdemos.github.io/cdn-simulator/"
   />
   <LinkCard
     icon="f5xc:platform"
     title="Alle Komponenten anzeigen"
-    description="Durchsuchen Sie den vollständigen Demo-Ressourcenkatalog."
+    description="Den vollständigen Demo-Ressourcen-Katalog durchsuchen."
     href="https://f5xc-salesdemos.github.io/demo-resources/"
   />
 </CardGrid>
@@ -131,13 +127,13 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
 <CardGrid>
   <LinkCard
     icon="f5xc:observability"
-    title="Observability"
-    description="Überwachung, Metriken und Anwendungs-Insights."
+    title="Beobachtbarkeit"
+    description="Überwachung, Metriken und Anwendungseinblicke."
     href="https://f5xc-salesdemos.github.io/observability/"
   />
   <LinkCard
     icon="f5xc:administration"
-    title="Administration"
+    title="Verwaltung"
     description="Mandantenverwaltung, RBAC und Plattformeinstellungen."
     href="https://f5xc-salesdemos.github.io/administration/"
   />
@@ -155,13 +151,13 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
   <LinkCard
     icon="f5xc:data-intelligence"
     title="API-Spezifikationen"
-    description="OpenAPI-Spezifikationsvalidierung und -Abgleich für F5 Distributed Cloud."
+    description="OpenAPI-Spezifikationsvalidierung und -Abstimmung für F5 Distributed Cloud."
     href="https://f5xc-salesdemos.github.io/api-specs/"
   />
   <LinkCard
     icon="f5xc:data-intelligence"
     title="Erweiterte API-Spezifikationen"
-    description="Angereicherte OpenAPI-Spezifikationen für F5 Distributed Cloud."
+    description="Erweiterte OpenAPI-Spezifikationen für F5 Distributed Cloud."
     href="https://f5xc-salesdemos.github.io/api-specs-enriched/"
   />
 </CardGrid>
@@ -184,7 +180,7 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
   <LinkCard
     icon="f5xc:distributed-apps"
     title="Icons"
-    description="NPM-Icon-Pakete und Plugins für das Dokumentations-Build-System."
+    description="NPM-Symbolpakete und Plugins für das Dokumentations-Build-System."
     href="https://f5xc-salesdemos.github.io/docs-icons/"
   />
   <LinkCard
@@ -195,8 +191,8 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
   />
   <LinkCard
     icon="hashicorp-flight:docker-color"
-    title="Dev Container"
-    description="Isolierte Entwicklungsumgebung mit KI-gestützten Coding-Tools."
+    title="Entwicklungscontainer"
+    description="Isolierte Entwicklungsumgebung mit KI-Programmierwerkzeugen."
     href="https://f5xc-salesdemos.github.io/devcontainer/"
   />
 </CardGrid>
@@ -206,8 +202,8 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
 <CardGrid>
   <LinkCard
     icon="f5xc:distributed-apps"
-    title="VS Code-Erweiterung"
-    description="Verwalten Sie F5 XC-Ressourcen in VS Code mit IntelliSense und dem xcsh-Chat-Assistenten."
+    title="VS Code Erweiterung"
+    description="F5 XC-Ressourcen aus VS Code verwalten mit IntelliSense und xcsh-Chat-Assistent."
     href="https://f5xc-salesdemos.github.io/vscode-f5xc-tools/"
   />
   <LinkCard

--- a/docs/es/index.mdx
+++ b/docs/es/index.mdx
@@ -1,14 +1,14 @@
 ---
-title: Demos de Ventas de F5 Distributed Cloud
+title: F5 Distributed Cloud Sales Demos
 description: >-
-  Guías de demostración y runbooks para ingeniería de ventas de F5 Distributed
-  Cloud.
+  Guías de demostración y runbooks para la ingeniería de ventas de F5
+  Distributed Cloud.
 template: splash
 hero:
-  title: Demos de Ventas
+  title: Demostraciones de ventas
   tagline: >-
-    Guías de demostración y runbooks para ingeniería de ventas de F5 Distributed
-    Cloud.
+    Guías de demostración y runbooks para la ingeniería de ventas de F5
+    Distributed Cloud.
   image:
     html: >-
       <img src="/docs/images/hero-platform.svg" alt="F5 Distributed Cloud
@@ -27,7 +27,7 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
   <LinkCard
     icon="f5xc:web-app-and-api-protection"
     title="WAF"
-    description="Configuración y políticas del firewall de aplicaciones web."
+    description="Configuración y políticas del firewall de aplicaciones web (WAF)."
     href="https://f5xc-salesdemos.github.io/waf/"
   />
   <LinkCard
@@ -38,26 +38,26 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
   />
   <LinkCard
     icon="f5xc:bot-defense"
-    title="Bot Avanzado"
-    description="Defensa avanzada contra bots con análisis de comportamiento."
+    title="Bot Advanced"
+    description="Defensa Bot avanzada con análisis de comportamiento."
     href="https://f5xc-salesdemos.github.io/bot-advanced/"
   />
   <LinkCard
     icon="f5xc:bot-defense"
-    title="Bot Estándar"
-    description="Defensa estándar contra bots con detección basada en firmas."
+    title="Bot Standard"
+    description="Defensa Bot estándar con detección basada en firmas."
     href="https://f5xc-salesdemos.github.io/bot-standard/"
   />
   <LinkCard
     icon="f5xc:client-side-defense"
     title="CSD"
-    description="Defensa del lado del cliente para amenazas basadas en navegador."
+    description="Defensa del lado del cliente para amenazas basadas en el navegador."
     href="https://f5xc-salesdemos.github.io/csd/"
   />
   <LinkCard
     icon="f5xc:ddos-and-transit-services"
     title="DDoS"
-    description="Protección contra denegación de servicio distribuida."
+    description="Protección DDoS contra ataques de denegación de servicio distribuido."
     href="https://f5xc-salesdemos.github.io/ddos/"
   />
   <LinkCard
@@ -68,13 +68,13 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
   />
 </CardGrid>
 
-## Redes &amp; Rendimiento
+## Redes y rendimiento
 
 <CardGrid>
   <LinkCard
     icon="f5xc:multi-cloud-network-connect"
     title="MCN"
-    description="Redes multi-nube y conectividad de sitios."
+    description="Redes multinube y conectividad de sitios."
     href="https://f5xc-salesdemos.github.io/mcn/"
   />
   <LinkCard
@@ -97,30 +97,30 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
   />
 </CardGrid>
 
-## Recursos de Demostración
+## Recursos de demostración
 
 <CardGrid>
   <LinkCard
     icon="f5xc:distributed-apps"
-    title="Servidor de Origen"
-    description="VM Ubuntu 24.04 con 9 aplicaciones web vulnerables para pruebas de WAF, API y defensa contra bots."
+    title="Servidor de origen"
+    description="VM Ubuntu 24.04 con 9 aplicaciones web vulnerables para pruebas de WAF, API y defensa bot."
     href="https://f5xc-salesdemos.github.io/origin-server/"
   />
   <LinkCard
     icon="f5xc:application-traffic-insight"
-    title="Generador de Tráfico"
-    description="VM de Azure con más de 50 herramientas de seguridad y 7 suites de ataque para generación de tráfico de demostración."
+    title="Generador de tráfico"
+    description="VM de Azure con más de 50 herramientas de seguridad y 7 suites de ataque para la generación de tráfico de demostración."
     href="https://f5xc-salesdemos.github.io/traffic-generator/"
   />
   <LinkCard
     icon="f5xc:content-delivery-network"
     title="Simulador CDN"
-    description="Simulador de nodo de borde CDN basado en NGINX con más de 67 encabezados específicos de proveedor."
+    description="Simulador de nodo de borde CDN basado en NGINX con más de 67 cabeceras específicas de proveedor."
     href="https://f5xc-salesdemos.github.io/cdn-simulator/"
   />
   <LinkCard
     icon="f5xc:platform"
-    title="Ver Todos los Componentes"
+    title="Ver todos los Componentes"
     description="Explore el catálogo completo de recursos de demostración."
     href="https://f5xc-salesdemos.github.io/demo-resources/"
   />
@@ -132,13 +132,13 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
   <LinkCard
     icon="f5xc:observability"
     title="Observabilidad"
-    description="Monitorización, métricas e información de aplicaciones."
+    description="Supervisión, métricas e información sobre aplicaciones."
     href="https://f5xc-salesdemos.github.io/observability/"
   />
   <LinkCard
     icon="f5xc:administration"
     title="Administración"
-    description="Gestión de tenants, RBAC y configuración de plataforma."
+    description="Gestión de inquilinos, RBAC y configuración de la Plataforma."
     href="https://f5xc-salesdemos.github.io/administration/"
   />
 </CardGrid>
@@ -160,60 +160,60 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
   />
   <LinkCard
     icon="f5xc:data-intelligence"
-    title="Especificaciones de API Enriquecidas"
+    title="Especificaciones de API enriquecidas"
     description="Especificaciones OpenAPI enriquecidas para F5 Distributed Cloud."
     href="https://f5xc-salesdemos.github.io/api-specs-enriched/"
   />
 </CardGrid>
 
-## Plataforma &amp; Herramientas
+## Plataforma y Herramientas
 
 <CardGrid>
   <LinkCard
     icon="f5xc:doc"
     title="Constructor"
-    description="Sistema de compilación de documentación containerizado con Astro + Starlight."
+    description="Sistema de construcción de documentación Astro + Starlight en contenedor."
     href="https://f5xc-salesdemos.github.io/docs-builder/"
   />
   <LinkCard
     icon="f5xc:shared-configuration"
     title="Tema"
-    description="Marca y estilos compartidos para sitios de documentación."
+    description="Marca y estilo compartidos para los sitios de documentación."
     href="https://f5xc-salesdemos.github.io/docs-theme/"
   />
   <LinkCard
     icon="f5xc:distributed-apps"
     title="Iconos"
-    description="Paquetes de iconos NPM y plugins para el sistema de compilación de documentación."
+    description="Paquetes de iconos NPM y complementos para el sistema de construcción de documentación."
     href="https://f5xc-salesdemos.github.io/docs-icons/"
   />
   <LinkCard
     icon="f5xc:shared-configuration"
     title="Control"
-    description="Flujos de trabajo CI, plantillas de gobernanza y aplicación de configuración de repositorios."
+    description="Flujos de trabajo de CI, plantillas de gobernanza y cumplimiento de configuración de repositorios."
     href="https://f5xc-salesdemos.github.io/docs-control/"
   />
   <LinkCard
     icon="hashicorp-flight:docker-color"
-    title="Contenedor de Desarrollo"
-    description="Entorno de desarrollo aislado con herramientas de codificación con IA."
+    title="Contenedor de desarrollo"
+    description="Entorno de desarrollo aislado con herramientas de codificación de IA."
     href="https://f5xc-salesdemos.github.io/devcontainer/"
   />
 </CardGrid>
 
-## Herramientas para Desarrolladores
+## Herramientas para desarrolladores
 
 <CardGrid>
   <LinkCard
     icon="f5xc:distributed-apps"
-    title="Extensión de VS Code"
+    title="VS Code Extensión"
     description="Gestione recursos de F5 XC desde VS Code con IntelliSense y el asistente de chat xcsh."
     href="https://f5xc-salesdemos.github.io/vscode-f5xc-tools/"
   />
   <LinkCard
     icon="f5xc:ai_assistant_logo"
-    title="CLI xcsh"
-    description="Shell potenciado con IA para operaciones de F5 Distributed Cloud."
+    title="xcsh CLI"
+    description="Shell con tecnología de IA para operaciones de F5 Distributed Cloud."
     href="https://f5xc-salesdemos.github.io/xcsh/"
   />
 </CardGrid>
@@ -224,7 +224,7 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
   <LinkCard
     icon="f5xc:ai_assistant_logo"
     title="Marketplace"
-    description="Marketplace potenciado con IA para soluciones de F5 Distributed Cloud."
+    description="Marketplace con tecnología de IA para soluciones de F5 Distributed Cloud."
     href="https://f5xc-salesdemos.github.io/marketplace/"
   />
 </CardGrid>

--- a/docs/fr/index.mdx
+++ b/docs/fr/index.mdx
@@ -1,13 +1,13 @@
 ---
-title: Démonstrations commerciales F5 Distributed Cloud
+title: Démos commerciales F5 Distributed Cloud
 description: >-
-  Guides de démonstration et runbooks pour l'ingénierie avant-vente F5
+  Guides de démonstration et runbooks pour l'ingénierie commerciale F5
   Distributed Cloud.
 template: splash
 hero:
-  title: Démonstrations commerciales
+  title: Démos commerciales
   tagline: >-
-    Guides de démonstration et runbooks pour l'ingénierie avant-vente F5
+    Guides de démonstration et runbooks pour l'ingénierie commerciale F5
     Distributed Cloud.
   image:
     html: >-
@@ -21,31 +21,31 @@ i18n:
 import { CardGrid } from '@astrojs/starlight/components';
 import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
 
-## Solutions de sécurité
+## Solutions de Sécurité
 
 <CardGrid>
   <LinkCard
     icon="f5xc:web-app-and-api-protection"
     title="WAF"
-    description="Configuration et politiques de pare-feu applicatif web."
+    description="Configuration et politiques du pare-feu applicatif."
     href="https://f5xc-salesdemos.github.io/waf/"
   />
   <LinkCard
     icon="f5xc:web-app-and-api-protection"
     title="API"
-    description="Découverte d'API, protection et politiques de sécurité."
+    description="Découverte des API, protection et politiques de sécurité."
     href="https://f5xc-salesdemos.github.io/api-protection/"
   />
   <LinkCard
     icon="f5xc:bot-defense"
-    title="Bot Avancé"
-    description="Défense avancée contre les bots avec analyse comportementale."
+    title="Bot Advanced"
+    description="Défense Bot avancée avec analyse comportementale."
     href="https://f5xc-salesdemos.github.io/bot-advanced/"
   />
   <LinkCard
     icon="f5xc:bot-defense"
     title="Bot Standard"
-    description="Défense standard contre les bots avec détection basée sur les signatures."
+    description="Défense Bot standard avec détection basée sur les signatures."
     href="https://f5xc-salesdemos.github.io/bot-standard/"
   />
   <LinkCard
@@ -63,7 +63,7 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
   <LinkCard
     icon="f5xc:web-app-scanning"
     title="WAS"
-    description="Analyse d'applications web et évaluation des vulnérabilités."
+    description="Analyse des applications web et évaluation des vulnérabilités."
     href="https://f5xc-salesdemos.github.io/was/"
   />
 </CardGrid>
@@ -74,19 +74,19 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
   <LinkCard
     icon="f5xc:multi-cloud-network-connect"
     title="MCN"
-    description="Réseau multi-cloud et connectivité inter-sites."
+    description="Réseau multi-cloud et connectivité des sites."
     href="https://f5xc-salesdemos.github.io/mcn/"
   />
   <LinkCard
     icon="f5xc:content-delivery-network"
     title="CDN"
-    description="Réseau de diffusion de contenu et mise en cache en périphérie."
+    description="Réseau de distribution de contenu et mise en cache à la périphérie."
     href="https://f5xc-salesdemos.github.io/cdn/"
   />
   <LinkCard
     icon="f5xc:dns-management"
     title="DNS"
-    description="Gestion DNS, zones et répartition de charge."
+    description="Gestion DNS, zones et équilibrage de charge DNS."
     href="https://f5xc-salesdemos.github.io/dns/"
   />
   <LinkCard
@@ -103,13 +103,13 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
   <LinkCard
     icon="f5xc:distributed-apps"
     title="Serveur d'origine"
-    description="VM Ubuntu 24.04 avec 9 applications web vulnérables pour les tests WAF, API et défense contre les bots."
+    description="Machine virtuelle Ubuntu 24.04 avec 9 applications web vulnérables pour les tests WAF, API et de défense bot."
     href="https://f5xc-salesdemos.github.io/origin-server/"
   />
   <LinkCard
     icon="f5xc:application-traffic-insight"
     title="Générateur de trafic"
-    description="VM Azure avec plus de 50 outils de sécurité et 7 suites d'attaques pour la génération de trafic de démonstration."
+    description="Machine virtuelle Azure avec plus de 50 outils de sécurité et 7 suites d'attaques pour la génération de trafic de démonstration."
     href="https://f5xc-salesdemos.github.io/traffic-generator/"
   />
   <LinkCard
@@ -120,7 +120,7 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
   />
   <LinkCard
     icon="f5xc:platform"
-    title="Voir tous les composants"
+    title="Voir tous les Composants"
     description="Parcourir le catalogue complet des ressources de démonstration."
     href="https://f5xc-salesdemos.github.io/demo-resources/"
   />
@@ -138,7 +138,7 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
   <LinkCard
     icon="f5xc:administration"
     title="Administration"
-    description="Gestion des tenants, RBAC et paramètres de la plateforme."
+    description="Gestion des locataires, RBAC et paramètres de la plateforme."
     href="https://f5xc-salesdemos.github.io/administration/"
   />
 </CardGrid>
@@ -166,54 +166,54 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
   />
 </CardGrid>
 
-## Plateforme &amp; Outillage
+## Plateforme &amp; Outils
 
 <CardGrid>
   <LinkCard
     icon="f5xc:doc"
     title="Builder"
-    description="Système de build de documentation conteneurisé Astro + Starlight."
+    description="Système de génération de documentation conteneurisé Astro + Starlight."
     href="https://f5xc-salesdemos.github.io/docs-builder/"
   />
   <LinkCard
     icon="f5xc:shared-configuration"
-    title="Thème"
-    description="Identité visuelle et styles partagés pour les sites de documentation."
+    title="Theme"
+    description="Image de marque et styles partagés pour les sites de documentation."
     href="https://f5xc-salesdemos.github.io/docs-theme/"
   />
   <LinkCard
     icon="f5xc:distributed-apps"
-    title="Icônes"
-    description="Packages d'icônes NPM et plugins pour le système de build de documentation."
+    title="Icons"
+    description="Paquets d'icônes NPM et plugins pour le système de génération de documentation."
     href="https://f5xc-salesdemos.github.io/docs-icons/"
   />
   <LinkCard
     icon="f5xc:shared-configuration"
-    title="Contrôle"
+    title="Control"
     description="Workflows CI, modèles de gouvernance et application des paramètres de dépôt."
     href="https://f5xc-salesdemos.github.io/docs-control/"
   />
   <LinkCard
     icon="hashicorp-flight:docker-color"
     title="Conteneur de développement"
-    description="Environnement de développement isolé avec outils de codage IA."
+    description="Environnement de développement isolé avec des outils de codage IA."
     href="https://f5xc-salesdemos.github.io/devcontainer/"
   />
 </CardGrid>
 
-## Outils pour développeurs
+## Outils de développement
 
 <CardGrid>
   <LinkCard
     icon="f5xc:distributed-apps"
     title="Extension VS Code"
-    description="Gérez les ressources F5 XC depuis VS Code avec IntelliSense et l'assistant de chat xcsh."
+    description="Gérez les ressources F5 XC depuis VS Code avec IntelliSense et l'assistant de discussion xcsh."
     href="https://f5xc-salesdemos.github.io/vscode-f5xc-tools/"
   />
   <LinkCard
     icon="f5xc:ai_assistant_logo"
-    title="CLI xcsh"
-    description="Shell alimenté par l'IA pour les opérations F5 Distributed Cloud."
+    title="xcsh CLI"
+    description="Interface shell alimentée par IA pour les opérations F5 Distributed Cloud."
     href="https://f5xc-salesdemos.github.io/xcsh/"
   />
 </CardGrid>
@@ -223,8 +223,8 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
 <CardGrid>
   <LinkCard
     icon="f5xc:ai_assistant_logo"
-    title="Marketplace"
-    description="Marketplace alimenté par l'IA pour les solutions F5 Distributed Cloud."
+    title="Place de marché"
+    description="Place de marché alimentée par IA pour les solutions F5 Distributed Cloud."
     href="https://f5xc-salesdemos.github.io/marketplace/"
   />
 </CardGrid>

--- a/docs/hi/index.mdx
+++ b/docs/hi/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: F5 Distributed Cloud सेल्स डेमो
+title: F5 Distributed Cloud Sales Demos
 description: F5 Distributed Cloud सेल्स इंजीनियरिंग के लिए डेमो गाइड और रनबुक।
 template: splash
 hero:
@@ -34,37 +34,37 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
   />
   <LinkCard
     icon="f5xc:bot-defense"
-    title="Bot एडवांस्ड"
-    description="व्यवहार विश्लेषण के साथ उन्नत बॉट सुरक्षा।"
+    title="Bot Advanced"
+    description="व्यवहार विश्लेषण के साथ Bot उन्नत रक्षा।"
     href="https://f5xc-salesdemos.github.io/bot-advanced/"
   />
   <LinkCard
     icon="f5xc:bot-defense"
-    title="Bot स्टैंडर्ड"
-    description="सिग्नेचर-आधारित पहचान के साथ मानक बॉट सुरक्षा।"
+    title="Bot Standard"
+    description="सिग्नेचर-आधारित पहचान के साथ Bot मानक रक्षा।"
     href="https://f5xc-salesdemos.github.io/bot-standard/"
   />
   <LinkCard
     icon="f5xc:client-side-defense"
     title="CSD"
-    description="ब्राउज़र-आधारित खतरों के लिए क्लाइंट-साइड सुरक्षा।"
+    description="ब्राउज़र-आधारित खतरों के लिए क्लाइंट-साइड डिफेंस।"
     href="https://f5xc-salesdemos.github.io/csd/"
   />
   <LinkCard
     icon="f5xc:ddos-and-transit-services"
     title="DDoS"
-    description="वितरित सेवा-अस्वीकार (DDoS) सुरक्षा।"
+    description="डिस्ट्रीब्यूटेड डिनायल-ऑफ-सर्विस DDoS सुरक्षा।"
     href="https://f5xc-salesdemos.github.io/ddos/"
   />
   <LinkCard
     icon="f5xc:web-app-scanning"
     title="WAS"
-    description="वेब एप्लिकेशन स्कैनिंग और भेद्यता मूल्यांकन।"
+    description="वेब ऐप स्कैनिंग और भेद्यता मूल्यांकन।"
     href="https://f5xc-salesdemos.github.io/was/"
   />
 </CardGrid>
 
-## नेटवर्किंग &amp; प्रदर्शन
+## नेटवर्किंग और प्रदर्शन
 
 <CardGrid>
   <LinkCard
@@ -82,7 +82,7 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
   <LinkCard
     icon="f5xc:dns-management"
     title="DNS"
-    description="DNS प्रबंधन, ज़ोन, और लोड बैलेंसिंग।"
+    description="DNS प्रबंधन, ज़ोन, और DNS लोड बैलेंसिंग।"
     href="https://f5xc-salesdemos.github.io/dns/"
   />
   <LinkCard
@@ -98,25 +98,25 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
 <CardGrid>
   <LinkCard
     icon="f5xc:distributed-apps"
-    title="ओरिजिन सर्वर"
-    description="WAF, API, और बॉट सुरक्षा परीक्षण के लिए 9 कमज़ोर वेब एप्लिकेशन के साथ Ubuntu 24.04 VM।"
+    title="ऑरिजिन सर्वर"
+    description="WAF, API, और बॉट डिफेंस परीक्षण के लिए 9 कमज़ोर वेब एप्लिकेशन के साथ Ubuntu 24.04 VM।"
     href="https://f5xc-salesdemos.github.io/origin-server/"
   />
   <LinkCard
     icon="f5xc:application-traffic-insight"
     title="ट्रैफ़िक जनरेटर"
-    description="डेमो ट्रैफ़िक जनरेशन के लिए 50+ सुरक्षा उपकरणों और 7 अटैक सुइट्स के साथ Azure VM।"
+    description="डेमो ट्रैफ़िक जनरेशन के लिए 50+ सुरक्षा उपकरण और 7 अटैक सूट के साथ Azure VM।"
     href="https://f5xc-salesdemos.github.io/traffic-generator/"
   />
   <LinkCard
     icon="f5xc:content-delivery-network"
     title="CDN सिम्युलेटर"
-    description="67+ वेंडर-विशिष्ट हेडर के साथ NGINX-आधारित CDN एज नोड सिम्युलेटर।"
+    description="67+ विक्रेता-विशिष्ट हेडर के साथ NGINX-आधारित CDN एज नोड सिम्युलेटर।"
     href="https://f5xc-salesdemos.github.io/cdn-simulator/"
   />
   <LinkCard
     icon="f5xc:platform"
-    title="सभी कम्पोनेंट देखें"
+    title="सभी घटक देखें"
     description="पूर्ण डेमो संसाधन कैटलॉग ब्राउज़ करें।"
     href="https://f5xc-salesdemos.github.io/demo-resources/"
   />
@@ -127,8 +127,8 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
 <CardGrid>
   <LinkCard
     icon="f5xc:observability"
-    title="ऑब्ज़र्वेबिलिटी"
-    description="मॉनिटरिंग, मेट्रिक्स, और एप्लिकेशन इनसाइट्स।"
+    title="अवलोकनीयता"
+    description="निगरानी, मेट्रिक्स, और एप्लिकेशन अंतर्दृष्टि।"
     href="https://f5xc-salesdemos.github.io/observability/"
   />
   <LinkCard
@@ -150,60 +150,60 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
   />
   <LinkCard
     icon="f5xc:data-intelligence"
-    title="API स्पेक्स"
-    description="F5 Distributed Cloud के लिए OpenAPI स्पेक सत्यापन और समाधान।"
+    title="API विनिर्देश"
+    description="F5 Distributed Cloud के लिए OpenAPI स्पेक सत्यापन और सुलह।"
     href="https://f5xc-salesdemos.github.io/api-specs/"
   />
   <LinkCard
     icon="f5xc:data-intelligence"
-    title="API स्पेक्स एनरिच्ड"
-    description="F5 Distributed Cloud के लिए समृद्ध OpenAPI विनिर्देश।"
+    title="संवर्धित API विनिर्देश"
+    description="F5 Distributed Cloud के लिए संवर्धित OpenAPI विनिर्देश।"
     href="https://f5xc-salesdemos.github.io/api-specs-enriched/"
   />
 </CardGrid>
 
-## प्लेटफ़ॉर्म &amp; टूलिंग
+## प्लेटफ़ॉर्म और टूलिंग
 
 <CardGrid>
   <LinkCard
     icon="f5xc:doc"
     title="बिल्डर"
-    description="कंटेनराइज़्ड Astro + Starlight डॉक्यूमेंटेशन बिल्ड सिस्टम।"
+    description="कंटेनरीकृत Astro + Starlight दस्तावेज़ीकरण बिल्ड सिस्टम।"
     href="https://f5xc-salesdemos.github.io/docs-builder/"
   />
   <LinkCard
     icon="f5xc:shared-configuration"
     title="थीम"
-    description="डॉक्यूमेंटेशन साइट्स के लिए साझा ब्रांडिंग और स्टाइलिंग।"
+    description="दस्तावेज़ीकरण साइटों के लिए साझा ब्रांडिंग और स्टाइलिंग।"
     href="https://f5xc-salesdemos.github.io/docs-theme/"
   />
   <LinkCard
     icon="f5xc:distributed-apps"
     title="आइकन"
-    description="डॉक्यूमेंटेशन बिल्ड सिस्टम के लिए NPM आइकन पैकेज और प्लगइन्स।"
+    description="दस्तावेज़ीकरण बिल्ड सिस्टम के लिए NPM आइकन पैकेज और प्लगइन।"
     href="https://f5xc-salesdemos.github.io/docs-icons/"
   />
   <LinkCard
     icon="f5xc:shared-configuration"
     title="कंट्रोल"
-    description="CI वर्कफ़्लो, गवर्नेंस टेम्पलेट्स, और रेपो सेटिंग्स एनफ़ोर्समेंट।"
+    description="CI वर्कफ़्लो, गवर्नेंस टेम्पलेट, और रेपो सेटिंग्स प्रवर्तन।"
     href="https://f5xc-salesdemos.github.io/docs-control/"
   />
   <LinkCard
     icon="hashicorp-flight:docker-color"
     title="डेव कंटेनर"
-    description="AI कोडिंग टूल्स के साथ पृथक विकास वातावरण।"
+    description="AI कोडिंग उपकरण के साथ पृथक विकास वातावरण।"
     href="https://f5xc-salesdemos.github.io/devcontainer/"
   />
 </CardGrid>
 
-## डेवलपर टूल्स
+## डेवलपर उपकरण
 
 <CardGrid>
   <LinkCard
     icon="f5xc:distributed-apps"
     title="VS Code एक्सटेंशन"
-    description="IntelliSense और xcsh चैट असिस्टेंट के साथ VS Code से F5 XC संसाधनों का प्रबंधन करें।"
+    description="IntelliSense और xcsh चैट असिस्टेंट के साथ VS Code से F5 XC संसाधन प्रबंधित करें।"
     href="https://f5xc-salesdemos.github.io/vscode-f5xc-tools/"
   />
   <LinkCard

--- a/docs/it/index.mdx
+++ b/docs/it/index.mdx
@@ -1,14 +1,10 @@
 ---
-title: Demo commerciali F5 Distributed Cloud
-description: >-
-  Guide dimostrative e runbook per l'ingegneria commerciale di F5 Distributed
-  Cloud.
+title: F5 Distributed Cloud Sales Demos
+description: Guide demo e runbook per il sales engineering di F5 Distributed Cloud.
 template: splash
 hero:
-  title: Demo commerciali
-  tagline: >-
-    Guide dimostrative e runbook per l'ingegneria commerciale di F5 Distributed
-    Cloud.
+  title: Demo di vendita
+  tagline: Guide demo e runbook per il sales engineering di F5 Distributed Cloud.
   image:
     html: >-
       <img src="/docs/images/hero-platform.svg" alt="F5 Distributed Cloud
@@ -21,13 +17,13 @@ i18n:
 import { CardGrid } from '@astrojs/starlight/components';
 import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
 
-## Soluzioni di sicurezza
+## Soluzioni di Sicurezza
 
 <CardGrid>
   <LinkCard
     icon="f5xc:web-app-and-api-protection"
     title="WAF"
-    description="Configurazione e policy del web application firewall."
+    description="Configurazione e policy del firewall per applicazioni web."
     href="https://f5xc-salesdemos.github.io/waf/"
   />
   <LinkCard
@@ -38,26 +34,26 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
   />
   <LinkCard
     icon="f5xc:bot-defense"
-    title="Bot Avanzato"
-    description="Difesa avanzata contro i bot con analisi comportamentale."
+    title="Bot Advanced"
+    description="Difesa Bot avanzata con analisi comportamentale."
     href="https://f5xc-salesdemos.github.io/bot-advanced/"
   />
   <LinkCard
     icon="f5xc:bot-defense"
     title="Bot Standard"
-    description="Difesa standard contro i bot con rilevamento basato su firme."
+    description="Difesa Bot standard con rilevamento basato su firma."
     href="https://f5xc-salesdemos.github.io/bot-standard/"
   />
   <LinkCard
     icon="f5xc:client-side-defense"
     title="CSD"
-    description="Difesa lato client per minacce basate sul browser."
+    description="Difesa lato client per le minacce basate su browser."
     href="https://f5xc-salesdemos.github.io/csd/"
   />
   <LinkCard
     icon="f5xc:ddos-and-transit-services"
     title="DDoS"
-    description="Protezione contro attacchi distributed denial-of-service."
+    description="Protezione DDoS contro gli attacchi di tipo distributed denial-of-service."
     href="https://f5xc-salesdemos.github.io/ddos/"
   />
   <LinkCard
@@ -68,19 +64,19 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
   />
 </CardGrid>
 
-## Rete &amp; Prestazioni
+## Rete e Prestazioni
 
 <CardGrid>
   <LinkCard
     icon="f5xc:multi-cloud-network-connect"
     title="MCN"
-    description="Networking multi-cloud e connettività tra siti."
+    description="Rete multi-cloud e connettività dei siti."
     href="https://f5xc-salesdemos.github.io/mcn/"
   />
   <LinkCard
     icon="f5xc:content-delivery-network"
     title="CDN"
-    description="Content delivery network e caching edge."
+    description="Rete di distribuzione dei contenuti e caching edge."
     href="https://f5xc-salesdemos.github.io/cdn/"
   />
   <LinkCard
@@ -103,25 +99,25 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
   <LinkCard
     icon="f5xc:distributed-apps"
     title="Server di origine"
-    description="VM Ubuntu 24.04 con 9 applicazioni web vulnerabili per test WAF, API e difesa contro i bot."
+    description="VM Ubuntu 24.04 con 9 applicazioni web vulnerabili per il test di WAF, API e difesa bot."
     href="https://f5xc-salesdemos.github.io/origin-server/"
   />
   <LinkCard
     icon="f5xc:application-traffic-insight"
     title="Generatore di traffico"
-    description="VM Azure con oltre 50 strumenti di sicurezza e 7 suite di attacco per la generazione di traffico demo."
+    description="VM Azure con oltre 50 strumenti di sicurezza e 7 suite di attacchi per la generazione di traffico demo."
     href="https://f5xc-salesdemos.github.io/traffic-generator/"
   />
   <LinkCard
     icon="f5xc:content-delivery-network"
     title="Simulatore CDN"
-    description="Simulatore di nodo edge CDN basato su NGINX con oltre 67 header specifici per vendor."
+    description="Simulatore di nodo edge CDN basato su NGINX con oltre 67 header specifici per fornitore."
     href="https://f5xc-salesdemos.github.io/cdn-simulator/"
   />
   <LinkCard
     icon="f5xc:platform"
-    title="Visualizza tutti i componenti"
-    description="Esplora il catalogo completo delle risorse demo."
+    title="Visualizza tutti i Componenti"
+    description="Sfoglia il catalogo completo delle risorse demo."
     href="https://f5xc-salesdemos.github.io/demo-resources/"
   />
 </CardGrid>
@@ -132,13 +128,13 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
   <LinkCard
     icon="f5xc:observability"
     title="Osservabilità"
-    description="Monitoraggio, metriche e insight sulle applicazioni."
+    description="Monitoraggio, metriche e informazioni sulle applicazioni."
     href="https://f5xc-salesdemos.github.io/observability/"
   />
   <LinkCard
     icon="f5xc:administration"
     title="Amministrazione"
-    description="Gestione del tenant, RBAC e impostazioni della piattaforma."
+    description="Gestione dei tenant, RBAC e impostazioni della piattaforma."
     href="https://f5xc-salesdemos.github.io/administration/"
   />
 </CardGrid>
@@ -166,37 +162,37 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
   />
 </CardGrid>
 
-## Piattaforma &amp; Strumenti
+## Piattaforma e Strumenti
 
 <CardGrid>
   <LinkCard
     icon="f5xc:doc"
     title="Builder"
-    description="Sistema di build per documentazione containerizzato basato su Astro + Starlight."
+    description="Sistema di build della documentazione containerizzato con Astro + Starlight."
     href="https://f5xc-salesdemos.github.io/docs-builder/"
   />
   <LinkCard
     icon="f5xc:shared-configuration"
-    title="Tema"
+    title="Theme"
     description="Branding e stile condivisi per i siti di documentazione."
     href="https://f5xc-salesdemos.github.io/docs-theme/"
   />
   <LinkCard
     icon="f5xc:distributed-apps"
-    title="Icone"
+    title="Icons"
     description="Pacchetti di icone NPM e plugin per il sistema di build della documentazione."
     href="https://f5xc-salesdemos.github.io/docs-icons/"
   />
   <LinkCard
     icon="f5xc:shared-configuration"
-    title="Controllo"
+    title="Control"
     description="Workflow CI, template di governance e applicazione delle impostazioni dei repository."
     href="https://f5xc-salesdemos.github.io/docs-control/"
   />
   <LinkCard
     icon="hashicorp-flight:docker-color"
-    title="Dev Container"
-    description="Ambiente di sviluppo isolato con strumenti di coding basati su IA."
+    title="Contenitore di sviluppo"
+    description="Ambiente di sviluppo isolato con strumenti IA per la programmazione."
     href="https://f5xc-salesdemos.github.io/devcontainer/"
   />
 </CardGrid>
@@ -206,14 +202,14 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
 <CardGrid>
   <LinkCard
     icon="f5xc:distributed-apps"
-    title="Estensione VS Code"
-    description="Gestisci le risorse F5 XC da VS Code con IntelliSense e l'assistente chat xcsh."
+    title="VS Code Estensione"
+    description="Gestisci le risorse F5 XC da VS Code con IntelliSense e l'assistente di chat xcsh."
     href="https://f5xc-salesdemos.github.io/vscode-f5xc-tools/"
   />
   <LinkCard
     icon="f5xc:ai_assistant_logo"
-    title="CLI xcsh"
-    description="Shell basata su IA per le operazioni F5 Distributed Cloud."
+    title="xcsh CLI"
+    description="Shell basata su IA per le operazioni di F5 Distributed Cloud."
     href="https://f5xc-salesdemos.github.io/xcsh/"
   />
 </CardGrid>

--- a/docs/ja/index.mdx
+++ b/docs/ja/index.mdx
@@ -1,10 +1,10 @@
 ---
 title: F5 Distributed Cloud セールスデモ
-description: F5 Distributed Cloud セールスエンジニアリング向けデモガイドおよびランブック。
+description: F5 Distributed Cloud セールスエンジニアリング向けのデモガイドおよびランブック。
 template: splash
 hero:
   title: セールスデモ
-  tagline: F5 Distributed Cloud セールスエンジニアリング向けデモガイドおよびランブック。
+  tagline: F5 Distributed Cloud セールスエンジニアリング向けのデモガイドおよびランブック。
   image:
     html: >-
       <img src="/docs/images/hero-platform.svg" alt="F5 Distributed Cloud
@@ -23,25 +23,25 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
   <LinkCard
     icon="f5xc:web-app-and-api-protection"
     title="WAF"
-    description="Webアプリケーションファイアウォールの設定とポリシー。"
+    description="Web アプリファイアウォール (WAF) の設定とポリシー。"
     href="https://f5xc-salesdemos.github.io/waf/"
   />
   <LinkCard
     icon="f5xc:web-app-and-api-protection"
     title="API"
-    description="APIディスカバリ、保護、およびセキュリティポリシー。"
+    description="API の検出、保護、およびセキュリティポリシー。"
     href="https://f5xc-salesdemos.github.io/api-protection/"
   />
   <LinkCard
     icon="f5xc:bot-defense"
     title="Bot Advanced"
-    description="行動分析による高度なボット防御。"
+    description="行動分析による Bot 高度防御。"
     href="https://f5xc-salesdemos.github.io/bot-advanced/"
   />
   <LinkCard
     icon="f5xc:bot-defense"
     title="Bot Standard"
-    description="シグネチャベース検出による標準ボット防御。"
+    description="シグネチャベースの検出による Bot 標準防御。"
     href="https://f5xc-salesdemos.github.io/bot-standard/"
   />
   <LinkCard
@@ -53,42 +53,42 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
   <LinkCard
     icon="f5xc:ddos-and-transit-services"
     title="DDoS"
-    description="分散型サービス拒否攻撃からの保護。"
+    description="分散型サービス拒否攻撃に対する DDoS 対策。"
     href="https://f5xc-salesdemos.github.io/ddos/"
   />
   <LinkCard
     icon="f5xc:web-app-scanning"
     title="WAS"
-    description="Webアプリケーションスキャンと脆弱性評価。"
+    description="Web アプリスキャンおよび脆弱性評価。"
     href="https://f5xc-salesdemos.github.io/was/"
   />
 </CardGrid>
 
-## ネットワーキング &amp; パフォーマンス
+## ネットワークとパフォーマンス
 
 <CardGrid>
   <LinkCard
     icon="f5xc:multi-cloud-network-connect"
     title="MCN"
-    description="マルチクラウドネットワーキングとサイト接続。"
+    description="マルチクラウドネットワークおよびサイト接続。"
     href="https://f5xc-salesdemos.github.io/mcn/"
   />
   <LinkCard
     icon="f5xc:content-delivery-network"
     title="CDN"
-    description="コンテンツデリバリーネットワークとエッジキャッシング。"
+    description="コンテンツ配信ネットワークおよびエッジキャッシング。"
     href="https://f5xc-salesdemos.github.io/cdn/"
   />
   <LinkCard
     icon="f5xc:dns-management"
     title="DNS"
-    description="DNS管理、ゾーン、およびロードバランシング。"
+    description="DNS 管理、ゾーン、および DNS ロードバランシング。"
     href="https://f5xc-salesdemos.github.io/dns/"
   />
   <LinkCard
     icon="f5xc:nginx-one"
     title="NGINX"
-    description="NGINXの統合と構成管理。"
+    description="NGINX インテグレーションおよび構成管理。"
     href="https://f5xc-salesdemos.github.io/nginx/"
   />
 </CardGrid>
@@ -99,30 +99,30 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
   <LinkCard
     icon="f5xc:distributed-apps"
     title="オリジンサーバー"
-    description="WAF、API、およびボット防御テスト用の9つの脆弱なWebアプリケーションを搭載したUbuntu 24.04 VM。"
+    description="WAF、API、および Bot 防御テスト用の脆弱な Web アプリケーションを 9 種類搭載した Ubuntu 24.04 VM。"
     href="https://f5xc-salesdemos.github.io/origin-server/"
   />
   <LinkCard
     icon="f5xc:application-traffic-insight"
     title="トラフィックジェネレーター"
-    description="デモトラフィック生成用の50以上のセキュリティツールと7つの攻撃スイートを搭載したAzure VM。"
+    description="デモトラフィック生成用の 50 以上のセキュリティツールと 7 つの攻撃スイートを備えた Azure VM。"
     href="https://f5xc-salesdemos.github.io/traffic-generator/"
   />
   <LinkCard
     icon="f5xc:content-delivery-network"
-    title="CDNシミュレーター"
-    description="67以上のベンダー固有ヘッダーを備えたNGINXベースのCDNエッジノードシミュレーター。"
+    title="CDN シミュレーター"
+    description="67 以上のベンダー固有ヘッダーを持つ NGINX ベースの CDN エッジノードシミュレーター。"
     href="https://f5xc-salesdemos.github.io/cdn-simulator/"
   />
   <LinkCard
     icon="f5xc:platform"
-    title="全コンポーネントを表示"
+    title="すべてのコンポーネントを表示"
     description="デモリソースの完全なカタログを参照する。"
     href="https://f5xc-salesdemos.github.io/demo-resources/"
   />
 </CardGrid>
 
-## 運用
+## オペレーション
 
 <CardGrid>
   <LinkCard
@@ -144,55 +144,55 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
 <CardGrid>
   <LinkCard
     icon="hashicorp-flight:terraform-color"
-    title="Terraformプロバイダー"
-    description="F5 Distributed Cloud用Terraformプロバイダー。"
+    title="Terraform プロバイダー"
+    description="F5 Distributed Cloud 向け Terraform プロバイダー。"
     href="https://f5xc-salesdemos.github.io/terraform-provider-f5xc/"
   />
   <LinkCard
     icon="f5xc:data-intelligence"
-    title="API仕様"
-    description="F5 Distributed Cloud向けOpenAPI仕様の検証と照合。"
+    title="API 仕様"
+    description="F5 Distributed Cloud 向け OpenAPI 仕様の検証と照合。"
     href="https://f5xc-salesdemos.github.io/api-specs/"
   />
   <LinkCard
     icon="f5xc:data-intelligence"
-    title="エンリッチAPI仕様"
-    description="F5 Distributed Cloud向けエンリッチOpenAPI仕様。"
+    title="拡充 API 仕様"
+    description="F5 Distributed Cloud 向けの拡充 OpenAPI 仕様。"
     href="https://f5xc-salesdemos.github.io/api-specs-enriched/"
   />
 </CardGrid>
 
-## プラットフォーム &amp; ツール
+## プラットフォームとツール
 
 <CardGrid>
   <LinkCard
     icon="f5xc:doc"
-    title="ビルダー"
-    description="コンテナ化されたAstro + Starlightドキュメントビルドシステム。"
+    title="Builder"
+    description="コンテナ化された Astro + Starlight ドキュメントビルドシステム。"
     href="https://f5xc-salesdemos.github.io/docs-builder/"
   />
   <LinkCard
     icon="f5xc:shared-configuration"
-    title="テーマ"
-    description="ドキュメントサイト向け共有ブランディングとスタイリング。"
+    title="Theme"
+    description="ドキュメントサイト向けの共有ブランディングおよびスタイリング。"
     href="https://f5xc-salesdemos.github.io/docs-theme/"
   />
   <LinkCard
     icon="f5xc:distributed-apps"
-    title="アイコン"
-    description="ドキュメントビルドシステム用NPMアイコンパッケージとプラグイン。"
+    title="Icons"
+    description="ドキュメントビルドシステム向けの NPM アイコンパッケージおよびプラグイン。"
     href="https://f5xc-salesdemos.github.io/docs-icons/"
   />
   <LinkCard
     icon="f5xc:shared-configuration"
-    title="コントロール"
-    description="CIワークフロー、ガバナンステンプレート、およびリポジトリ設定の適用。"
+    title="Control"
+    description="CI ワークフロー、ガバナンステンプレート、およびリポジトリ設定の適用。"
     href="https://f5xc-salesdemos.github.io/docs-control/"
   />
   <LinkCard
     icon="hashicorp-flight:docker-color"
     title="開発コンテナ"
-    description="AIコーディングツールを備えた隔離された開発環境。"
+    description="AI コーディングツールを搭載した隔離された開発環境。"
     href="https://f5xc-salesdemos.github.io/devcontainer/"
   />
 </CardGrid>
@@ -202,14 +202,14 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
 <CardGrid>
   <LinkCard
     icon="f5xc:distributed-apps"
-    title="VS Code拡張機能"
-    description="IntelliSenseとxcshチャットアシスタントでVS CodeからF5 XCリソースを管理。"
+    title="VS Code 拡張機能"
+    description="IntelliSense および xcsh チャットアシスタントを使用して VS Code から F5 XC リソースを管理する。"
     href="https://f5xc-salesdemos.github.io/vscode-f5xc-tools/"
   />
   <LinkCard
     icon="f5xc:ai_assistant_logo"
     title="xcsh CLI"
-    description="F5 Distributed Cloud運用向けAI搭載シェル。"
+    description="F5 Distributed Cloud オペレーション向けの AI 搭載シェル。"
     href="https://f5xc-salesdemos.github.io/xcsh/"
   />
 </CardGrid>
@@ -220,7 +220,7 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
   <LinkCard
     icon="f5xc:ai_assistant_logo"
     title="マーケットプレイス"
-    description="F5 Distributed Cloudソリューション向けAI搭載マーケットプレイス。"
+    description="F5 Distributed Cloud ソリューション向けの AI 搭載マーケットプレイス。"
     href="https://f5xc-salesdemos.github.io/marketplace/"
   />
 </CardGrid>

--- a/docs/ko/index.mdx
+++ b/docs/ko/index.mdx
@@ -35,13 +35,13 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
   <LinkCard
     icon="f5xc:bot-defense"
     title="Bot Advanced"
-    description="행동 분석을 활용한 고급 봇 방어."
+    description="행동 분석을 통한 고급 봇 방어."
     href="https://f5xc-salesdemos.github.io/bot-advanced/"
   />
   <LinkCard
     icon="f5xc:bot-defense"
     title="Bot Standard"
-    description="시그니처 기반 탐지를 활용한 표준 봇 방어."
+    description="시그니처 기반 탐지를 통한 표준 봇 방어."
     href="https://f5xc-salesdemos.github.io/bot-standard/"
   />
   <LinkCard
@@ -53,7 +53,7 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
   <LinkCard
     icon="f5xc:ddos-and-transit-services"
     title="DDoS"
-    description="분산 서비스 거부 공격 방어."
+    description="분산 서비스 거부 공격 보호."
     href="https://f5xc-salesdemos.github.io/ddos/"
   />
   <LinkCard
@@ -76,13 +76,13 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
   <LinkCard
     icon="f5xc:content-delivery-network"
     title="CDN"
-    description="콘텐츠 전송 네트워크 및 엣지 캐싱."
+    description="콘텐츠 전달 네트워크 및 엣지 캐싱."
     href="https://f5xc-salesdemos.github.io/cdn/"
   />
   <LinkCard
     icon="f5xc:dns-management"
     title="DNS"
-    description="DNS 관리, 존 및 로드 밸런싱."
+    description="DNS 관리, 영역 및 부하 분산."
     href="https://f5xc-salesdemos.github.io/dns/"
   />
   <LinkCard
@@ -99,13 +99,13 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
   <LinkCard
     icon="f5xc:distributed-apps"
     title="오리진 서버"
-    description="WAF, API 및 봇 방어 테스트를 위한 9개의 취약 웹 애플리케이션이 포함된 Ubuntu 24.04 VM."
+    description="WAF, API 및 봇 방어 테스트를 위한 9개의 취약한 웹 애플리케이션이 포함된 Ubuntu 24.04 VM."
     href="https://f5xc-salesdemos.github.io/origin-server/"
   />
   <LinkCard
     icon="f5xc:application-traffic-insight"
     title="트래픽 생성기"
-    description="데모 트래픽 생성을 위한 50개 이상의 보안 도구와 7개의 공격 모음이 포함된 Azure VM."
+    description="데모 트래픽 생성을 위한 50개 이상의 보안 도구 및 7개의 공격 스위트가 포함된 Azure VM."
     href="https://f5xc-salesdemos.github.io/traffic-generator/"
   />
   <LinkCard
@@ -116,7 +116,7 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
   />
   <LinkCard
     icon="f5xc:platform"
-    title="전체 구성 요소 보기"
+    title="모든 구성 요소 보기"
     description="전체 데모 리소스 카탈로그를 탐색합니다."
     href="https://f5xc-salesdemos.github.io/demo-resources/"
   />
@@ -127,7 +127,7 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
 <CardGrid>
   <LinkCard
     icon="f5xc:observability"
-    title="옵저버빌리티"
+    title="관측 가능성"
     description="모니터링, 메트릭 및 애플리케이션 인사이트."
     href="https://f5xc-salesdemos.github.io/observability/"
   />
@@ -150,14 +150,14 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
   />
   <LinkCard
     icon="f5xc:data-intelligence"
-    title="API 스펙"
-    description="F5 Distributed Cloud용 OpenAPI 스펙 검증 및 조정."
+    title="API 사양"
+    description="F5 Distributed Cloud를 위한 OpenAPI 사양 유효성 검사 및 조정."
     href="https://f5xc-salesdemos.github.io/api-specs/"
   />
   <LinkCard
     icon="f5xc:data-intelligence"
-    title="API 스펙 강화판"
-    description="F5 Distributed Cloud용 강화된 OpenAPI 사양."
+    title="강화된 API 사양"
+    description="F5 Distributed Cloud를 위한 강화된 OpenAPI 사양."
     href="https://f5xc-salesdemos.github.io/api-specs-enriched/"
   />
 </CardGrid>
@@ -180,13 +180,13 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
   <LinkCard
     icon="f5xc:distributed-apps"
     title="아이콘"
-    description="문서 빌드 시스템용 NPM 아이콘 패키지 및 플러그인."
+    description="문서 빌드 시스템을 위한 NPM 아이콘 패키지 및 플러그인."
     href="https://f5xc-salesdemos.github.io/docs-icons/"
   />
   <LinkCard
     icon="f5xc:shared-configuration"
     title="컨트롤"
-    description="CI 워크플로, 거버넌스 템플릿 및 저장소 설정 적용."
+    description="CI 워크플로우, 거버넌스 템플릿 및 리포지토리 설정 적용."
     href="https://f5xc-salesdemos.github.io/docs-control/"
   />
   <LinkCard
@@ -203,7 +203,7 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
   <LinkCard
     icon="f5xc:distributed-apps"
     title="VS Code 확장"
-    description="IntelliSense와 xcsh 채팅 어시스턴트를 통해 VS Code에서 F5 XC 리소스를 관리합니다."
+    description="IntelliSense 및 xcsh 채팅 어시스턴트를 통해 VS Code에서 F5 XC 리소스를 관리합니다."
     href="https://f5xc-salesdemos.github.io/vscode-f5xc-tools/"
   />
   <LinkCard

--- a/docs/pt-br/index.mdx
+++ b/docs/pt-br/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Demonstrações de Vendas do F5 Distributed Cloud
+title: Demonstrações de Vendas F5 Distributed Cloud
 description: >-
   Guias de demonstração e runbooks para engenharia de vendas do F5 Distributed
   Cloud.
@@ -27,13 +27,13 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
   <LinkCard
     icon="f5xc:web-app-and-api-protection"
     title="WAF"
-    description="Configuração e políticas de firewall de aplicações web."
+    description="Configuração e políticas de firewall para aplicações web."
     href="https://f5xc-salesdemos.github.io/waf/"
   />
   <LinkCard
     icon="f5xc:web-app-and-api-protection"
     title="API"
-    description="Descoberta de API, proteção e políticas de segurança."
+    description="Descoberta, proteção e políticas de segurança de API."
     href="https://f5xc-salesdemos.github.io/api-protection/"
   />
   <LinkCard
@@ -51,7 +51,7 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
   <LinkCard
     icon="f5xc:client-side-defense"
     title="CSD"
-    description="Defesa do lado do cliente para ameaças baseadas em navegador."
+    description="Defesa no lado do cliente para ameaças baseadas em navegador."
     href="https://f5xc-salesdemos.github.io/csd/"
   />
   <LinkCard
@@ -68,13 +68,13 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
   />
 </CardGrid>
 
-## Rede &amp; Desempenho
+## Redes &amp; Desempenho
 
 <CardGrid>
   <LinkCard
     icon="f5xc:multi-cloud-network-connect"
     title="MCN"
-    description="Rede multi-cloud e conectividade de sites."
+    description="Redes multicloud e conectividade de sites."
     href="https://f5xc-salesdemos.github.io/mcn/"
   />
   <LinkCard
@@ -92,7 +92,7 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
   <LinkCard
     icon="f5xc:nginx-one"
     title="NGINX"
-    description="Integração NGINX e gerenciamento de configuração."
+    description="Integração e gerenciamento de configuração do NGINX."
     href="https://f5xc-salesdemos.github.io/nginx/"
   />
 </CardGrid>
@@ -115,7 +115,7 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
   <LinkCard
     icon="f5xc:content-delivery-network"
     title="Simulador de CDN"
-    description="Simulador de nó de borda CDN baseado em NGINX com mais de 67 cabeçalhos específicos de fornecedores."
+    description="Simulador de nó de borda CDN baseado em NGINX com mais de 67 cabeçalhos específicos por fornecedor."
     href="https://f5xc-salesdemos.github.io/cdn-simulator/"
   />
   <LinkCard
@@ -148,8 +148,8 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
 <CardGrid>
   <LinkCard
     icon="hashicorp-flight:terraform-color"
-    title="Provider Terraform"
-    description="Provider Terraform para F5 Distributed Cloud."
+    title="Provedor Terraform"
+    description="Provedor Terraform para F5 Distributed Cloud."
     href="https://f5xc-salesdemos.github.io/terraform-provider-f5xc/"
   />
   <LinkCard
@@ -172,25 +172,25 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
   <LinkCard
     icon="f5xc:doc"
     title="Builder"
-    description="Sistema de build de documentação Astro + Starlight containerizado."
+    description="Sistema de compilação de documentação Astro + Starlight em contêiner."
     href="https://f5xc-salesdemos.github.io/docs-builder/"
   />
   <LinkCard
     icon="f5xc:shared-configuration"
     title="Tema"
-    description="Identidade visual e estilização compartilhadas para sites de documentação."
+    description="Identidade visual e estilos compartilhados para sites de documentação."
     href="https://f5xc-salesdemos.github.io/docs-theme/"
   />
   <LinkCard
     icon="f5xc:distributed-apps"
     title="Ícones"
-    description="Pacotes NPM de ícones e plugins para o sistema de build de documentação."
+    description="Pacotes de ícones NPM e plugins para o sistema de compilação de documentação."
     href="https://f5xc-salesdemos.github.io/docs-icons/"
   />
   <LinkCard
     icon="f5xc:shared-configuration"
     title="Controle"
-    description="Workflows de CI, templates de governança e aplicação de configurações de repositório."
+    description="Fluxos de trabalho de CI, modelos de governança e aplicação de configurações de repositório."
     href="https://f5xc-salesdemos.github.io/docs-control/"
   />
   <LinkCard
@@ -207,13 +207,13 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
   <LinkCard
     icon="f5xc:distributed-apps"
     title="Extensão VS Code"
-    description="Gerencie recursos do F5 XC a partir do VS Code com IntelliSense e assistente de chat xcsh."
+    description="Gerencie recursos F5 XC a partir do VS Code com IntelliSense e assistente de chat xcsh."
     href="https://f5xc-salesdemos.github.io/vscode-f5xc-tools/"
   />
   <LinkCard
     icon="f5xc:ai_assistant_logo"
-    title="CLI xcsh"
-    description="Shell com IA para operações do F5 Distributed Cloud."
+    title="xcsh CLI"
+    description="Shell com inteligência artificial para operações do F5 Distributed Cloud."
     href="https://f5xc-salesdemos.github.io/xcsh/"
   />
 </CardGrid>
@@ -224,7 +224,7 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
   <LinkCard
     icon="f5xc:ai_assistant_logo"
     title="Marketplace"
-    description="Marketplace com IA para soluções F5 Distributed Cloud."
+    description="Marketplace com inteligência artificial para soluções F5 Distributed Cloud."
     href="https://f5xc-salesdemos.github.io/marketplace/"
   />
 </CardGrid>

--- a/docs/th/index.mdx
+++ b/docs/th/index.mdx
@@ -1,10 +1,10 @@
 ---
-title: สาธิตการขาย F5 Distributed Cloud
-description: คู่มือสาธิตและ Runbook สำหรับวิศวกรรมการขาย F5 Distributed Cloud
+title: F5 Distributed Cloud Sales Demos
+description: คู่มือการสาธิตและรันบุ๊กสำหรับวิศวกรฝ่ายขาย F5 Distributed Cloud
 template: splash
 hero:
-  title: สาธิตการขาย
-  tagline: คู่มือสาธิตและ Runbook สำหรับวิศวกรรมการขาย F5 Distributed Cloud
+  title: การสาธิตการขาย
+  tagline: คู่มือการสาธิตและรันบุ๊กสำหรับวิศวกรฝ่ายขาย F5 Distributed Cloud
   image:
     html: >-
       <img src="/docs/images/hero-platform.svg" alt="F5 Distributed Cloud
@@ -17,37 +17,37 @@ i18n:
 import { CardGrid } from '@astrojs/starlight/components';
 import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
 
-## โซลูชันด้านความปลอดภัย
+## โซลูชันความปลอดภัย
 
 <CardGrid>
   <LinkCard
     icon="f5xc:web-app-and-api-protection"
     title="WAF"
-    description="การกำหนดค่าและนโยบาย Web Application Firewall"
+    description="การกำหนดค่าและนโยบายไฟร์วอลล์แอปพลิเคชันเว็บ"
     href="https://f5xc-salesdemos.github.io/waf/"
   />
   <LinkCard
     icon="f5xc:web-app-and-api-protection"
     title="API"
-    description="การค้นหา API, การป้องกัน และนโยบายความปลอดภัย"
+    description="การค้นพบ API การป้องกัน และนโยบายความปลอดภัย"
     href="https://f5xc-salesdemos.github.io/api-protection/"
   />
   <LinkCard
     icon="f5xc:bot-defense"
-    title="Bot ขั้นสูง"
+    title="Bot Advanced"
     description="การป้องกัน Bot ขั้นสูงด้วยการวิเคราะห์พฤติกรรม"
     href="https://f5xc-salesdemos.github.io/bot-advanced/"
   />
   <LinkCard
     icon="f5xc:bot-defense"
-    title="Bot มาตรฐาน"
+    title="Bot Standard"
     description="การป้องกัน Bot มาตรฐานด้วยการตรวจจับแบบ Signature"
     href="https://f5xc-salesdemos.github.io/bot-standard/"
   />
   <LinkCard
     icon="f5xc:client-side-defense"
     title="CSD"
-    description="การป้องกันฝั่งไคลเอนต์สำหรับภัยคุกคามผ่านเบราว์เซอร์"
+    description="การป้องกันฝั่งไคลเอนต์สำหรับภัยคุกคามที่มาจากเบราว์เซอร์"
     href="https://f5xc-salesdemos.github.io/csd/"
   />
   <LinkCard
@@ -59,7 +59,7 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
   <LinkCard
     icon="f5xc:web-app-scanning"
     title="WAS"
-    description="การสแกนเว็บแอปพลิเคชันและการประเมินช่องโหว่"
+    description="การสแกนแอปพลิเคชันเว็บและการประเมินช่องโหว่"
     href="https://f5xc-salesdemos.github.io/was/"
   />
 </CardGrid>
@@ -76,13 +76,13 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
   <LinkCard
     icon="f5xc:content-delivery-network"
     title="CDN"
-    description="เครือข่ายจัดส่งเนื้อหาและการแคชที่ Edge"
+    description="เครือข่ายการส่งมอบเนื้อหาและการแคชที่ Edge"
     href="https://f5xc-salesdemos.github.io/cdn/"
   />
   <LinkCard
     icon="f5xc:dns-management"
     title="DNS"
-    description="การจัดการ DNS, โซน และการกระจายโหลด"
+    description="การจัดการ DNS โซน และการกระจายโหลด"
     href="https://f5xc-salesdemos.github.io/dns/"
   />
   <LinkCard
@@ -93,31 +93,31 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
   />
 </CardGrid>
 
-## ทรัพยากรสำหรับการสาธิต
+## ทรัพยากรสาธิต
 
 <CardGrid>
   <LinkCard
     icon="f5xc:distributed-apps"
     title="เซิร์ฟเวอร์ต้นทาง"
-    description="VM Ubuntu 24.04 พร้อมเว็บแอปพลิเคชันที่มีช่องโหว่ 9 รายการสำหรับทดสอบ WAF, API และการป้องกัน Bot"
+    description="VM Ubuntu 24.04 พร้อมแอปพลิเคชันเว็บที่มีช่องโหว่ 9 รายการสำหรับทดสอบ WAF API และการป้องกัน Bot"
     href="https://f5xc-salesdemos.github.io/origin-server/"
   />
   <LinkCard
     icon="f5xc:application-traffic-insight"
     title="ตัวสร้างทราฟฟิก"
-    description="Azure VM พร้อมเครื่องมือความปลอดภัยกว่า 50 รายการและชุดโจมตี 7 ชุดสำหรับสร้างทราฟฟิกสาธิต"
+    description="Azure VM พร้อมเครื่องมือความปลอดภัยกว่า 50 รายการและชุดการโจมตี 7 ชุดสำหรับการสร้างทราฟฟิกสาธิต"
     href="https://f5xc-salesdemos.github.io/traffic-generator/"
   />
   <LinkCard
     icon="f5xc:content-delivery-network"
     title="ตัวจำลอง CDN"
-    description="ตัวจำลอง CDN Edge Node ที่ใช้ NGINX พร้อม Header เฉพาะผู้ให้บริการกว่า 67 รายการ"
+    description="ตัวจำลอง CDN Edge Node ที่ใช้ NGINX พร้อม Header เฉพาะผู้ขายกว่า 67 รายการ"
     href="https://f5xc-salesdemos.github.io/cdn-simulator/"
   />
   <LinkCard
     icon="f5xc:platform"
     title="ดูส่วนประกอบทั้งหมด"
-    description="เรียกดูแคตตาล็อกทรัพยากรสาธิตฉบับสมบูรณ์"
+    description="เรียกดูแคตาล็อกทรัพยากรสาธิตทั้งหมด"
     href="https://f5xc-salesdemos.github.io/demo-resources/"
   />
 </CardGrid>
@@ -133,13 +133,13 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
   />
   <LinkCard
     icon="f5xc:administration"
-    title="การบริหารจัดการ"
-    description="การจัดการ Tenant, RBAC และการตั้งค่าแพลตฟอร์ม"
+    title="การบริหาร"
+    description="การจัดการ Tenant RBAC และการตั้งค่าแพลตฟอร์ม"
     href="https://f5xc-salesdemos.github.io/administration/"
   />
 </CardGrid>
 
-## ระบบอัตโนมัติ
+## การทำงานอัตโนมัติ
 
 <CardGrid>
   <LinkCard
@@ -150,14 +150,14 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
   />
   <LinkCard
     icon="f5xc:data-intelligence"
-    title="API Specs"
-    description="การตรวจสอบและการปรับเทียบ OpenAPI Spec สำหรับ F5 Distributed Cloud"
+    title="ข้อกำหนด API"
+    description="การตรวจสอบความถูกต้องของ OpenAPI Spec และการประสานสำหรับ F5 Distributed Cloud"
     href="https://f5xc-salesdemos.github.io/api-specs/"
   />
   <LinkCard
     icon="f5xc:data-intelligence"
-    title="API Specs แบบเสริม"
-    description="ข้อกำหนด OpenAPI แบบเสริมสำหรับ F5 Distributed Cloud"
+    title="ข้อกำหนด API ที่เพิ่มประสิทธิภาพ"
+    description="OpenAPI Specification ที่เพิ่มประสิทธิภาพสำหรับ F5 Distributed Cloud"
     href="https://f5xc-salesdemos.github.io/api-specs-enriched/"
   />
 </CardGrid>
@@ -167,32 +167,32 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
 <CardGrid>
   <LinkCard
     icon="f5xc:doc"
-    title="ตัวสร้าง"
-    description="ระบบสร้างเอกสาร Astro + Starlight แบบ Container"
+    title="Builder"
+    description="ระบบสร้างเอกสารแบบ Containerized ด้วย Astro + Starlight"
     href="https://f5xc-salesdemos.github.io/docs-builder/"
   />
   <LinkCard
     icon="f5xc:shared-configuration"
-    title="ธีม"
-    description="การสร้างแบรนด์และการจัดรูปแบบที่ใช้ร่วมกันสำหรับเว็บไซต์เอกสาร"
+    title="Theme"
+    description="การสร้างแบรนด์และสไตล์ที่ใช้ร่วมกันสำหรับเว็บไซต์เอกสาร"
     href="https://f5xc-salesdemos.github.io/docs-theme/"
   />
   <LinkCard
     icon="f5xc:distributed-apps"
-    title="ไอคอน"
-    description="แพ็คเกจไอคอน NPM และปลั๊กอินสำหรับระบบสร้างเอกสาร"
+    title="Icons"
+    description="แพ็กเกจไอคอน NPM และปลั๊กอินสำหรับระบบสร้างเอกสาร"
     href="https://f5xc-salesdemos.github.io/docs-icons/"
   />
   <LinkCard
     icon="f5xc:shared-configuration"
-    title="การควบคุม"
-    description="CI Workflow, เทมเพลตกำกับดูแล และการบังคับใช้การตั้งค่า Repository"
+    title="Control"
+    description="เวิร์กโฟลว์ CI เทมเพลตการกำกับดูแล และการบังคับใช้การตั้งค่า Repository"
     href="https://f5xc-salesdemos.github.io/docs-control/"
   />
   <LinkCard
     icon="hashicorp-flight:docker-color"
-    title="Dev Container"
-    description="สภาพแวดล้อมการพัฒนาแบบแยกส่วนพร้อมเครื่องมือเขียนโค้ด AI"
+    title="คอนเทนเนอร์สำหรับพัฒนา"
+    description="สภาพแวดล้อมการพัฒนาแบบแยกส่วนพร้อมเครื่องมือ AI สำหรับเขียนโค้ด"
     href="https://f5xc-salesdemos.github.io/devcontainer/"
   />
 </CardGrid>
@@ -202,14 +202,14 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
 <CardGrid>
   <LinkCard
     icon="f5xc:distributed-apps"
-    title="ส่วนขยาย VS Code"
-    description="จัดการทรัพยากร F5 XC จาก VS Code พร้อม IntelliSense และผู้ช่วย xcsh chat"
+    title="VS Code ส่วนขยาย"
+    description="จัดการทรัพยากร F5 XC จาก VS Code ด้วย IntelliSense และผู้ช่วยแชท xcsh"
     href="https://f5xc-salesdemos.github.io/vscode-f5xc-tools/"
   />
   <LinkCard
     icon="f5xc:ai_assistant_logo"
     title="xcsh CLI"
-    description="เชลล์ที่ขับเคลื่อนด้วย AI สำหรับการดำเนินงาน F5 Distributed Cloud"
+    description="Shell ที่ขับเคลื่อนด้วย AI สำหรับการดำเนินงาน F5 Distributed Cloud"
     href="https://f5xc-salesdemos.github.io/xcsh/"
   />
 </CardGrid>

--- a/docs/zh-cn/index.mdx
+++ b/docs/zh-cn/index.mdx
@@ -1,10 +1,10 @@
 ---
 title: F5 分布式云销售演示
-description: F5 分布式云销售工程的演示指南和运行手册。
+description: F5 分布式云销售工程师的演示指南和操作手册。
 template: splash
 hero:
   title: 销售演示
-  tagline: F5 分布式云销售工程的演示指南和运行手册。
+  tagline: F5 分布式云销售工程师的演示指南和操作手册。
   image:
     html: >-
       <img src="/docs/images/hero-platform.svg" alt="F5 Distributed Cloud
@@ -29,25 +29,25 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
   <LinkCard
     icon="f5xc:web-app-and-api-protection"
     title="API"
-    description="API 发现、保护与安全策略。"
+    description="API 发现、防护及安全策略。"
     href="https://f5xc-salesdemos.github.io/api-protection/"
   />
   <LinkCard
     icon="f5xc:bot-defense"
-    title="高级 Bot 防护"
-    description="基于行为分析的高级 Bot 防护。"
+    title="Bot Advanced"
+    description="基于行为分析的高级机器人防御。"
     href="https://f5xc-salesdemos.github.io/bot-advanced/"
   />
   <LinkCard
     icon="f5xc:bot-defense"
-    title="标准 Bot 防护"
-    description="基于签名检测的标准 Bot 防护。"
+    title="Bot Standard"
+    description="基于特征检测的标准机器人防御。"
     href="https://f5xc-salesdemos.github.io/bot-standard/"
   />
   <LinkCard
     icon="f5xc:client-side-defense"
     title="CSD"
-    description="针对浏览器端威胁的客户端防护。"
+    description="针对浏览器端威胁的客户端防御。"
     href="https://f5xc-salesdemos.github.io/csd/"
   />
   <LinkCard
@@ -70,7 +70,7 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
   <LinkCard
     icon="f5xc:multi-cloud-network-connect"
     title="MCN"
-    description="多云网络与站点连接。"
+    description="多云网络与站点互联。"
     href="https://f5xc-salesdemos.github.io/mcn/"
   />
   <LinkCard
@@ -82,7 +82,7 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
   <LinkCard
     icon="f5xc:dns-management"
     title="DNS"
-    description="DNS 管理、域区与负载均衡。"
+    description="DNS 管理、区域配置与负载均衡。"
     href="https://f5xc-salesdemos.github.io/dns/"
   />
   <LinkCard
@@ -98,31 +98,31 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
 <CardGrid>
   <LinkCard
     icon="f5xc:distributed-apps"
-    title="源站服务器"
-    description="基于 Ubuntu 24.04 的虚拟机，包含 9 个存在漏洞的 Web 应用，用于 WAF、API 和 Bot 防护测试。"
+    title="源服务器"
+    description="搭载 9 个存在漏洞的 Web 应用的 Ubuntu 24.04 虚拟机，用于 WAF、API 及机器人防御测试。"
     href="https://f5xc-salesdemos.github.io/origin-server/"
   />
   <LinkCard
     icon="f5xc:application-traffic-insight"
     title="流量生成器"
-    description="Azure 虚拟机，配备 50 多种安全工具和 7 套攻击套件，用于生成演示流量。"
+    description="搭载 50 余种安全工具和 7 个攻击套件的 Azure 虚拟机，用于演示流量生成。"
     href="https://f5xc-salesdemos.github.io/traffic-generator/"
   />
   <LinkCard
     icon="f5xc:content-delivery-network"
     title="CDN 模拟器"
-    description="基于 NGINX 的 CDN 边缘节点模拟器，支持 67 种以上厂商特定头部。"
+    description="基于 NGINX 的 CDN 边缘节点模拟器，支持 67 种以上厂商专用请求头。"
     href="https://f5xc-salesdemos.github.io/cdn-simulator/"
   />
   <LinkCard
     icon="f5xc:platform"
-    title="查看所有组件"
+    title="查看全部组件"
     description="浏览完整的演示资源目录。"
     href="https://f5xc-salesdemos.github.io/demo-resources/"
   />
 </CardGrid>
 
-## 运维
+## 运营管理
 
 <CardGrid>
   <LinkCard
@@ -134,7 +134,7 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
   <LinkCard
     icon="f5xc:administration"
     title="管理"
-    description="租户管理、RBAC 与平台设置。"
+    description="租户管理、RBAC 及平台设置。"
     href="https://f5xc-salesdemos.github.io/administration/"
   />
 </CardGrid>
@@ -151,13 +151,13 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
   <LinkCard
     icon="f5xc:data-intelligence"
     title="API 规范"
-    description="F5 分布式云的 OpenAPI 规范验证与协调。"
+    description="适用于 F5 分布式云的 OpenAPI 规范验证与协调。"
     href="https://f5xc-salesdemos.github.io/api-specs/"
   />
   <LinkCard
     icon="f5xc:data-intelligence"
-    title="增强版 API 规范"
-    description="F5 分布式云的增强版 OpenAPI 规范。"
+    title="增强型 API 规范"
+    description="适用于 F5 分布式云的增强型 OpenAPI 规范。"
     href="https://f5xc-salesdemos.github.io/api-specs-enriched/"
   />
 </CardGrid>
@@ -168,25 +168,25 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
   <LinkCard
     icon="f5xc:doc"
     title="构建器"
-    description="容器化的 Astro + Starlight 文档构建系统。"
+    description="基于容器化 Astro + Starlight 的文档构建系统。"
     href="https://f5xc-salesdemos.github.io/docs-builder/"
   />
   <LinkCard
     icon="f5xc:shared-configuration"
     title="主题"
-    description="文档站点的共享品牌与样式。"
+    description="文档站点的共享品牌标识与样式。"
     href="https://f5xc-salesdemos.github.io/docs-theme/"
   />
   <LinkCard
     icon="f5xc:distributed-apps"
     title="图标"
-    description="文档构建系统的 NPM 图标包与插件。"
+    description="适用于文档构建系统的 NPM 图标包与插件。"
     href="https://f5xc-salesdemos.github.io/docs-icons/"
   />
   <LinkCard
     icon="f5xc:shared-configuration"
     title="管控"
-    description="CI 工作流、治理模板与仓库设置管理。"
+    description="CI 工作流、治理模板及代码仓库设置强制执行。"
     href="https://f5xc-salesdemos.github.io/docs-control/"
   />
   <LinkCard
@@ -203,24 +203,24 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
   <LinkCard
     icon="f5xc:distributed-apps"
     title="VS Code 扩展"
-    description="在 VS Code 中管理 F5 XC 资源，支持 IntelliSense 和 xcsh 聊天助手。"
+    description="通过 IntelliSense 和 xcsh 聊天助手在 VS Code 中管理 F5 XC 资源。"
     href="https://f5xc-salesdemos.github.io/vscode-f5xc-tools/"
   />
   <LinkCard
     icon="f5xc:ai_assistant_logo"
     title="xcsh CLI"
-    description="面向 F5 分布式云运维的 AI 驱动命令行工具。"
+    description="适用于 F5 分布式云运营的 AI 驱动命令行工具。"
     href="https://f5xc-salesdemos.github.io/xcsh/"
   />
 </CardGrid>
 
-## AI
+## 人工智能
 
 <CardGrid>
   <LinkCard
     icon="f5xc:ai_assistant_logo"
-    title="市场"
-    description="面向 F5 分布式云解决方案的 AI 驱动市场。"
+    title="应用市场"
+    description="适用于 F5 分布式云解决方案的 AI 驱动应用市场。"
     href="https://f5xc-salesdemos.github.io/marketplace/"
   />
 </CardGrid>

--- a/docs/zh-tw/index.mdx
+++ b/docs/zh-tw/index.mdx
@@ -1,10 +1,10 @@
 ---
-title: F5 Distributed Cloud 銷售展示
-description: F5 Distributed Cloud 銷售工程的展示指南與操作手冊。
+title: F5 Distributed Cloud 銷售示範
+description: F5 Distributed Cloud 銷售工程的示範指南與操作手冊。
 template: splash
 hero:
-  title: 銷售展示
-  tagline: F5 Distributed Cloud 銷售工程的展示指南與操作手冊。
+  title: 銷售示範
+  tagline: F5 Distributed Cloud 銷售工程的示範指南與操作手冊。
   image:
     html: >-
       <img src="/docs/images/hero-platform.svg" alt="F5 Distributed Cloud
@@ -23,13 +23,13 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
   <LinkCard
     icon="f5xc:web-app-and-api-protection"
     title="WAF"
-    description="網頁應用程式防火牆組態與策略。"
+    description="Web 應用程式防火牆設定與原則。"
     href="https://f5xc-salesdemos.github.io/waf/"
   />
   <LinkCard
     icon="f5xc:web-app-and-api-protection"
     title="API"
-    description="API 探索、防護與安全策略。"
+    description="API 探索、保護與安全原則。"
     href="https://f5xc-salesdemos.github.io/api-protection/"
   />
   <LinkCard
@@ -47,19 +47,19 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
   <LinkCard
     icon="f5xc:client-side-defense"
     title="CSD"
-    description="針對瀏覽器端威脅的用戶端防禦。"
+    description="針對瀏覽器型威脅的用戶端防禦。"
     href="https://f5xc-salesdemos.github.io/csd/"
   />
   <LinkCard
     icon="f5xc:ddos-and-transit-services"
     title="DDoS"
-    description="分散式阻斷服務防護。"
+    description="分散式阻斷服務攻擊防護。"
     href="https://f5xc-salesdemos.github.io/ddos/"
   />
   <LinkCard
     icon="f5xc:web-app-scanning"
     title="WAS"
-    description="網頁應用程式掃描與弱點評估。"
+    description="Web 應用程式掃描與弱點評估。"
     href="https://f5xc-salesdemos.github.io/was/"
   />
 </CardGrid>
@@ -70,7 +70,7 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
   <LinkCard
     icon="f5xc:multi-cloud-network-connect"
     title="MCN"
-    description="多雲網路連線與站點連接。"
+    description="多雲網路與站點連線。"
     href="https://f5xc-salesdemos.github.io/mcn/"
   />
   <LinkCard
@@ -82,42 +82,42 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
   <LinkCard
     icon="f5xc:dns-management"
     title="DNS"
-    description="DNS 管理、區域與負載平衡。"
+    description="DNS 管理、區域設定與負載平衡。"
     href="https://f5xc-salesdemos.github.io/dns/"
   />
   <LinkCard
     icon="f5xc:nginx-one"
     title="NGINX"
-    description="NGINX 整合與組態管理。"
+    description="NGINX 整合與設定管理。"
     href="https://f5xc-salesdemos.github.io/nginx/"
   />
 </CardGrid>
 
-## 展示資源
+## 示範資源
 
 <CardGrid>
   <LinkCard
     icon="f5xc:distributed-apps"
     title="來源伺服器"
-    description="Ubuntu 24.04 虛擬機，包含 9 個具有弱點的網頁應用程式，用於 WAF、API 與機器人防禦測試。"
+    description="搭載 9 個具漏洞 Web 應用程式的 Ubuntu 24.04 VM，用於 WAF、API 及機器人防禦測試。"
     href="https://f5xc-salesdemos.github.io/origin-server/"
   />
   <LinkCard
     icon="f5xc:application-traffic-insight"
     title="流量產生器"
-    description="Azure 虛擬機，包含 50+ 種安全工具與 7 套攻擊套件，用於展示流量產生。"
+    description="搭載 50 餘種安全工具與 7 套攻擊套件的 Azure VM，用於示範流量產生。"
     href="https://f5xc-salesdemos.github.io/traffic-generator/"
   />
   <LinkCard
     icon="f5xc:content-delivery-network"
     title="CDN 模擬器"
-    description="基於 NGINX 的 CDN 邊緣節點模擬器，支援 67+ 種供應商專屬標頭。"
+    description="基於 NGINX 的 CDN 邊緣節點模擬器，支援 67 種以上廠商專屬標頭。"
     href="https://f5xc-salesdemos.github.io/cdn-simulator/"
   />
   <LinkCard
     icon="f5xc:platform"
     title="檢視所有元件"
-    description="瀏覽完整的展示資源目錄。"
+    description="瀏覽完整的示範資源目錄。"
     href="https://f5xc-salesdemos.github.io/demo-resources/"
   />
 </CardGrid>
@@ -133,7 +133,7 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
   />
   <LinkCard
     icon="f5xc:administration"
-    title="管理"
+    title="系統管理"
     description="租戶管理、RBAC 與平台設定。"
     href="https://f5xc-salesdemos.github.io/administration/"
   />
@@ -144,20 +144,20 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
 <CardGrid>
   <LinkCard
     icon="hashicorp-flight:terraform-color"
-    title="Terraform Provider"
+    title="Terraform 提供者"
     description="適用於 F5 Distributed Cloud 的 Terraform 提供者。"
     href="https://f5xc-salesdemos.github.io/terraform-provider-f5xc/"
   />
   <LinkCard
     icon="f5xc:data-intelligence"
-    title="API 規範"
-    description="F5 Distributed Cloud 的 OpenAPI 規範驗證與調和。"
+    title="API 規格"
+    description="適用於 F5 Distributed Cloud 的 OpenAPI 規格驗證與調和。"
     href="https://f5xc-salesdemos.github.io/api-specs/"
   />
   <LinkCard
     icon="f5xc:data-intelligence"
-    title="API 增強規範"
-    description="F5 Distributed Cloud 的增強 OpenAPI 規範。"
+    title="API 規格（增強版）"
+    description="適用於 F5 Distributed Cloud 的增強版 OpenAPI 規格。"
     href="https://f5xc-salesdemos.github.io/api-specs-enriched/"
   />
 </CardGrid>
@@ -167,32 +167,32 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
 <CardGrid>
   <LinkCard
     icon="f5xc:doc"
-    title="建構器"
-    description="容器化的 Astro + Starlight 文件建構系統。"
+    title="建置工具"
+    description="容器化的 Astro + Starlight 文件建置系統。"
     href="https://f5xc-salesdemos.github.io/docs-builder/"
   />
   <LinkCard
     icon="f5xc:shared-configuration"
-    title="主題"
-    description="文件網站的共用品牌識別與樣式。"
+    title="佈景主題"
+    description="適用於文件網站的共用品牌與樣式。"
     href="https://f5xc-salesdemos.github.io/docs-theme/"
   />
   <LinkCard
     icon="f5xc:distributed-apps"
     title="圖示"
-    description="文件建構系統的 NPM 圖示套件與外掛。"
+    description="適用於文件建置系統的 NPM 圖示套件與外掛程式。"
     href="https://f5xc-salesdemos.github.io/docs-icons/"
   />
   <LinkCard
     icon="f5xc:shared-configuration"
-    title="控制"
+    title="控制中心"
     description="CI 工作流程、治理範本與儲存庫設定強制執行。"
     href="https://f5xc-salesdemos.github.io/docs-control/"
   />
   <LinkCard
     icon="hashicorp-flight:docker-color"
     title="開發容器"
-    description="具備 AI 程式設計工具的隔離開發環境。"
+    description="整合 AI 程式開發工具的隔離式開發環境。"
     href="https://f5xc-salesdemos.github.io/devcontainer/"
   />
 </CardGrid>
@@ -202,14 +202,14 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
 <CardGrid>
   <LinkCard
     icon="f5xc:distributed-apps"
-    title="VS Code 擴充套件"
-    description="從 VS Code 管理 F5 XC 資源，具備 IntelliSense 與 xcsh 聊天助理。"
+    title="VS Code 擴充功能"
+    description="透過 IntelliSense 與 xcsh 聊天助理，從 VS Code 管理 F5 XC 資源。"
     href="https://f5xc-salesdemos.github.io/vscode-f5xc-tools/"
   />
   <LinkCard
     icon="f5xc:ai_assistant_logo"
     title="xcsh CLI"
-    description="AI 驅動的 F5 Distributed Cloud 操作命令列工具。"
+    description="適用於 F5 Distributed Cloud 運維的 AI 驅動 Shell。"
     href="https://f5xc-salesdemos.github.io/xcsh/"
   />
 </CardGrid>
@@ -219,8 +219,8 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
 <CardGrid>
   <LinkCard
     icon="f5xc:ai_assistant_logo"
-    title="市集"
-    description="AI 驅動的 F5 Distributed Cloud 解決方案市集。"
+    title="應用市集"
+    description="適用於 F5 Distributed Cloud 解決方案的 AI 驅動應用市集。"
     href="https://f5xc-salesdemos.github.io/marketplace/"
   />
 </CardGrid>


### PR DESCRIPTION
## Summary
- Re-translated all locale files using docs-theme v3.5.5 glossary translator
- Product names now consistently translated using authoritative terms from mega-menu-translations.ts

Closes #555

## Test plan
- [ ] CI passes
- [ ] GitHub Pages deploy succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)