### PR TITLE
fix: add title to hero-platform.svg for a11y compliance

### DIFF
--- a/docs/images/hero-platform.svg
+++ b/docs/images/hero-platform.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 464 384" width="464" height="384">
+<title>F5 Distributed Cloud Platform</title>
 <style>
   :root {
     --color-N600: #0f1e57;


### PR DESCRIPTION
## Summary
Add `<title>` element to `docs/images/hero-platform.svg` for biome a11y compliance.

Closes #571

🤖 Generated with [Claude Code](https://claude.com/claude-code)