### PR TITLE
fix: correct superpowers/ gitignore path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -176,7 +176,7 @@ tui-debug.log
 *.cpuprofile
 .nyc_output/
 packages/ai/test/.temp-images/
-docs/superpowers/
+superpowers/
 !.xcsh/
 .xcsh/plugins/
 .pi_config/


### PR DESCRIPTION
Fixes the gitignore pattern for the superpowers/ working directory — was `docs/superpowers/` (wrong relative path), corrected to `superpowers/`.