### PR TITLE
feat: add xcsh Chrome Extension landing card + federated site

### DIFF
--- a/docs/ar/index.mdx
+++ b/docs/ar/index.mdx
@@ -212,6 +212,12 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     description="واجهة سطر أوامر مدعومة بالذكاء الاصطناعي لعمليات F5 Distributed Cloud."
     href="https://f5xc-salesdemos.github.io/xcsh/"
   />
+  <LinkCard
+    icon="f5xc:ai_assistant_logo"
+    title="إضافة xcsh لمتصفح Chrome"
+    description="تحكم في وحدة تحكم F5 Distributed Cloud باستخدام مساعد xcsh الذكي."
+    href="https://f5xc-salesdemos.github.io/xcsh-chrome-extension/"
+  />
 </CardGrid>
 
 ## الذكاء الاصطناعي

--- a/docs/ar/index.mdx
+++ b/docs/ar/index.mdx
@@ -10,7 +10,7 @@ hero:
       <img src="/docs/images/hero-platform.svg" alt="F5 Distributed Cloud
       platform" />
 i18n:
-  sourceHash: 9502e0988fe3
+  sourceHash: 29ed36f6adda
   translator: machine
 ---
 

--- a/docs/de/index.mdx
+++ b/docs/de/index.mdx
@@ -10,7 +10,7 @@ hero:
       <img src="/docs/images/hero-platform.svg" alt="F5 Distributed Cloud
       platform" />
 i18n:
-  sourceHash: 9502e0988fe3
+  sourceHash: 29ed36f6adda
   translator: machine
 ---
 

--- a/docs/de/index.mdx
+++ b/docs/de/index.mdx
@@ -212,6 +212,12 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     description="KI-gestützte Shell für F5 Distributed Cloud-Operationen."
     href="https://f5xc-salesdemos.github.io/xcsh/"
   />
+  <LinkCard
+    icon="f5xc:ai_assistant_logo"
+    title="xcsh Chrome-Erweiterung"
+    description="Steuern Sie die F5 Distributed Cloud-Konsole mit dem xcsh-KI-Assistenten."
+    href="https://f5xc-salesdemos.github.io/xcsh-chrome-extension/"
+  />
 </CardGrid>
 
 ## KI

--- a/docs/en/index.mdx
+++ b/docs/en/index.mdx
@@ -207,6 +207,12 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     description="AI-powered shell for F5 Distributed Cloud operations."
     href="https://f5xc-salesdemos.github.io/xcsh/"
   />
+  <LinkCard
+    icon="f5xc:ai_assistant_logo"
+    title="xcsh Chrome Extension"
+    description="Drive the F5 Distributed Cloud console with the xcsh AI assistant."
+    href="https://f5xc-salesdemos.github.io/xcsh-chrome-extension/"
+  />
 </CardGrid>
 
 ## AI

--- a/docs/es/index.mdx
+++ b/docs/es/index.mdx
@@ -216,6 +216,12 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     description="Shell con tecnología de IA para operaciones de F5 Distributed Cloud."
     href="https://f5xc-salesdemos.github.io/xcsh/"
   />
+  <LinkCard
+    icon="f5xc:ai_assistant_logo"
+    title="Extensión de Chrome xcsh"
+    description="Controla la consola de F5 Distributed Cloud con el asistente de IA xcsh."
+    href="https://f5xc-salesdemos.github.io/xcsh-chrome-extension/"
+  />
 </CardGrid>
 
 ## IA

--- a/docs/es/index.mdx
+++ b/docs/es/index.mdx
@@ -14,7 +14,7 @@ hero:
       <img src="/docs/images/hero-platform.svg" alt="F5 Distributed Cloud
       platform" />
 i18n:
-  sourceHash: 9502e0988fe3
+  sourceHash: 29ed36f6adda
   translator: machine
 ---
 

--- a/docs/fr/index.mdx
+++ b/docs/fr/index.mdx
@@ -216,6 +216,12 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     description="Interface shell alimentée par IA pour les opérations F5 Distributed Cloud."
     href="https://f5xc-salesdemos.github.io/xcsh/"
   />
+  <LinkCard
+    icon="f5xc:ai_assistant_logo"
+    title="Extension Chrome xcsh"
+    description="Pilotez la console F5 Distributed Cloud avec l'assistant IA xcsh."
+    href="https://f5xc-salesdemos.github.io/xcsh-chrome-extension/"
+  />
 </CardGrid>
 
 ## IA

--- a/docs/fr/index.mdx
+++ b/docs/fr/index.mdx
@@ -14,7 +14,7 @@ hero:
       <img src="/docs/images/hero-platform.svg" alt="F5 Distributed Cloud
       platform" />
 i18n:
-  sourceHash: 9502e0988fe3
+  sourceHash: 29ed36f6adda
   translator: machine
 ---
 

--- a/docs/hi/index.mdx
+++ b/docs/hi/index.mdx
@@ -212,6 +212,12 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     description="F5 Distributed Cloud संचालन के लिए AI-संचालित शेल।"
     href="https://f5xc-salesdemos.github.io/xcsh/"
   />
+  <LinkCard
+    icon="f5xc:ai_assistant_logo"
+    title="xcsh Chrome एक्सटेंशन"
+    description="xcsh AI सहायक के साथ F5 Distributed Cloud कंसोल चलाएं।"
+    href="https://f5xc-salesdemos.github.io/xcsh-chrome-extension/"
+  />
 </CardGrid>
 
 ## AI

--- a/docs/hi/index.mdx
+++ b/docs/hi/index.mdx
@@ -10,7 +10,7 @@ hero:
       <img src="/docs/images/hero-platform.svg" alt="F5 Distributed Cloud
       platform" />
 i18n:
-  sourceHash: 9502e0988fe3
+  sourceHash: 29ed36f6adda
   translator: machine
 ---
 

--- a/docs/it/index.mdx
+++ b/docs/it/index.mdx
@@ -10,7 +10,7 @@ hero:
       <img src="/docs/images/hero-platform.svg" alt="F5 Distributed Cloud
       platform" />
 i18n:
-  sourceHash: 9502e0988fe3
+  sourceHash: 29ed36f6adda
   translator: machine
 ---
 

--- a/docs/it/index.mdx
+++ b/docs/it/index.mdx
@@ -212,6 +212,12 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     description="Shell basata su IA per le operazioni di F5 Distributed Cloud."
     href="https://f5xc-salesdemos.github.io/xcsh/"
   />
+  <LinkCard
+    icon="f5xc:ai_assistant_logo"
+    title="Estensione Chrome xcsh"
+    description="Controlla la console F5 Distributed Cloud con l'assistente IA xcsh."
+    href="https://f5xc-salesdemos.github.io/xcsh-chrome-extension/"
+  />
 </CardGrid>
 
 ## IA

--- a/docs/ja/index.mdx
+++ b/docs/ja/index.mdx
@@ -212,6 +212,12 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     description="F5 Distributed Cloud オペレーション向けの AI 搭載シェル。"
     href="https://f5xc-salesdemos.github.io/xcsh/"
   />
+  <LinkCard
+    icon="f5xc:ai_assistant_logo"
+    title="xcsh Chrome 拡張機能"
+    description="xcsh AI アシスタントで F5 Distributed Cloud コンソールを操作。"
+    href="https://f5xc-salesdemos.github.io/xcsh-chrome-extension/"
+  />
 </CardGrid>
 
 ## AI

--- a/docs/ja/index.mdx
+++ b/docs/ja/index.mdx
@@ -10,7 +10,7 @@ hero:
       <img src="/docs/images/hero-platform.svg" alt="F5 Distributed Cloud
       platform" />
 i18n:
-  sourceHash: 9502e0988fe3
+  sourceHash: 29ed36f6adda
   translator: machine
 ---
 

--- a/docs/ko/index.mdx
+++ b/docs/ko/index.mdx
@@ -10,7 +10,7 @@ hero:
       <img src="/docs/images/hero-platform.svg" alt="F5 Distributed Cloud
       platform" />
 i18n:
-  sourceHash: 9502e0988fe3
+  sourceHash: 29ed36f6adda
   translator: machine
 ---
 

--- a/docs/ko/index.mdx
+++ b/docs/ko/index.mdx
@@ -212,6 +212,12 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     description="F5 Distributed Cloud 운영을 위한 AI 기반 셸."
     href="https://f5xc-salesdemos.github.io/xcsh/"
   />
+  <LinkCard
+    icon="f5xc:ai_assistant_logo"
+    title="xcsh Chrome 확장"
+    description="xcsh AI 어시스턴트로 F5 Distributed Cloud 콘솔을 제어하세요."
+    href="https://f5xc-salesdemos.github.io/xcsh-chrome-extension/"
+  />
 </CardGrid>
 
 ## AI

--- a/docs/llms-federated-sites.json
+++ b/docs/llms-federated-sites.json
@@ -144,6 +144,12 @@
     "category": "developer-tools"
   },
   {
+    "label": "xcsh Chrome Extension",
+    "url": "https://f5xc-salesdemos.github.io/xcsh-chrome-extension/llms.txt",
+    "description": "Chrome extension companion for the xcsh AI-powered F5 Distributed Cloud CLI",
+    "category": "developer-tools"
+  },
+  {
     "label": "CDN Simulator",
     "url": "https://f5xc-salesdemos.github.io/cdn-simulator/llms.txt",
     "description": "NGINX-based CDN edge node simulator for multi-vendor lab environments",

--- a/docs/pt-br/index.mdx
+++ b/docs/pt-br/index.mdx
@@ -14,7 +14,7 @@ hero:
       <img src="/docs/images/hero-platform.svg" alt="F5 Distributed Cloud
       platform" />
 i18n:
-  sourceHash: 9502e0988fe3
+  sourceHash: 29ed36f6adda
   translator: machine
 ---
 

--- a/docs/pt-br/index.mdx
+++ b/docs/pt-br/index.mdx
@@ -216,6 +216,12 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     description="Shell com inteligência artificial para operações do F5 Distributed Cloud."
     href="https://f5xc-salesdemos.github.io/xcsh/"
   />
+  <LinkCard
+    icon="f5xc:ai_assistant_logo"
+    title="Extensão do Chrome xcsh"
+    description="Controle o console do F5 Distributed Cloud com o assistente de IA xcsh."
+    href="https://f5xc-salesdemos.github.io/xcsh-chrome-extension/"
+  />
 </CardGrid>
 
 ## IA

--- a/docs/th/index.mdx
+++ b/docs/th/index.mdx
@@ -212,6 +212,12 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     description="Shell ที่ขับเคลื่อนด้วย AI สำหรับการดำเนินงาน F5 Distributed Cloud"
     href="https://f5xc-salesdemos.github.io/xcsh/"
   />
+  <LinkCard
+    icon="f5xc:ai_assistant_logo"
+    title="ส่วนขยาย Chrome ของ xcsh"
+    description="ควบคุมคอนโซล F5 Distributed Cloud ด้วยผู้ช่วย AI ของ xcsh"
+    href="https://f5xc-salesdemos.github.io/xcsh-chrome-extension/"
+  />
 </CardGrid>
 
 ## AI

--- a/docs/th/index.mdx
+++ b/docs/th/index.mdx
@@ -10,7 +10,7 @@ hero:
       <img src="/docs/images/hero-platform.svg" alt="F5 Distributed Cloud
       platform" />
 i18n:
-  sourceHash: 9502e0988fe3
+  sourceHash: 29ed36f6adda
   translator: machine
 ---
 

--- a/docs/zh-cn/index.mdx
+++ b/docs/zh-cn/index.mdx
@@ -212,6 +212,12 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     description="适用于 F5 分布式云运营的 AI 驱动命令行工具。"
     href="https://f5xc-salesdemos.github.io/xcsh/"
   />
+  <LinkCard
+    icon="f5xc:ai_assistant_logo"
+    title="xcsh Chrome 扩展"
+    description="使用 xcsh AI 助手驱动 F5 Distributed Cloud 控制台。"
+    href="https://f5xc-salesdemos.github.io/xcsh-chrome-extension/"
+  />
 </CardGrid>
 
 ## 人工智能

--- a/docs/zh-cn/index.mdx
+++ b/docs/zh-cn/index.mdx
@@ -10,7 +10,7 @@ hero:
       <img src="/docs/images/hero-platform.svg" alt="F5 Distributed Cloud
       platform" />
 i18n:
-  sourceHash: 9502e0988fe3
+  sourceHash: 29ed36f6adda
   translator: machine
 ---
 

--- a/docs/zh-tw/index.mdx
+++ b/docs/zh-tw/index.mdx
@@ -10,7 +10,7 @@ hero:
       <img src="/docs/images/hero-platform.svg" alt="F5 Distributed Cloud
       platform" />
 i18n:
-  sourceHash: 9502e0988fe3
+  sourceHash: 29ed36f6adda
   translator: machine
 ---
 

--- a/docs/zh-tw/index.mdx
+++ b/docs/zh-tw/index.mdx
@@ -212,6 +212,12 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     description="適用於 F5 Distributed Cloud 運維的 AI 驅動 Shell。"
     href="https://f5xc-salesdemos.github.io/xcsh/"
   />
+  <LinkCard
+    icon="f5xc:ai_assistant_logo"
+    title="xcsh Chrome 擴充功能"
+    description="使用 xcsh AI 助理驅動 F5 Distributed Cloud 主控台。"
+    href="https://f5xc-salesdemos.github.io/xcsh-chrome-extension/"
+  />
 </CardGrid>
 
 ## AI


### PR DESCRIPTION
Adds the xcsh-chrome-extension docs site to the landing page Developer Tools grid (13 locales) + federated sites. Closes #608.

🤖 Generated with [Claude Code](https://claude.com/claude-code)