### PR TITLE
chore: sync managed files from governance template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -182,6 +182,7 @@ packages/ai/test/.temp-images/
 docs/superpowers/
 !.xcsh/
 .xcsh/plugins/
+.xcsh/contexts/
 .pi_config/
 .opencode/
 .worktree-test-baseline.txt


### PR DESCRIPTION
Closes #618

Synced managed files from `f5xc-salesdemos/docs-control` canonical source:

- .gitignore