### PR TITLE
feat: add Console Catalog to landing page and federated sites

### DIFF
--- a/docs/ar/index.mdx
+++ b/docs/ar/index.mdx
@@ -10,7 +10,7 @@ hero:
       <img src="/docs/images/hero-platform.svg" alt="F5 Distributed Cloud
       platform" />
 i18n:
-  sourceHash: 29ed36f6adda
+  sourceHash: 72679f3e802e
   translator: machine
 ---
 
@@ -228,5 +228,11 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     title="السوق"
     description="السوق المدعوم بالذكاء الاصطناعي لحلول F5 Distributed Cloud."
     href="https://f5xc-salesdemos.github.io/marketplace/"
+  />
+  <LinkCard
+    icon="f5xc:ai_assistant_logo"
+    title="كتالوج وحدة التحكم"
+    description="كتالوج مدفوع بالمخطط لمسارات وحدة تحكم F5 XC والموارد وسير عمل أتمتة المتصفح لإدارة واجهة المستخدم المدفوعة بالذكاء الاصطناعي."
+    href="https://f5xc-salesdemos.github.io/console/"
   />
 </CardGrid>

--- a/docs/de/index.mdx
+++ b/docs/de/index.mdx
@@ -10,7 +10,7 @@ hero:
       <img src="/docs/images/hero-platform.svg" alt="F5 Distributed Cloud
       platform" />
 i18n:
-  sourceHash: 29ed36f6adda
+  sourceHash: 72679f3e802e
   translator: machine
 ---
 
@@ -228,5 +228,11 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     title="Marktplatz"
     description="KI-gestützter Marktplatz für F5 Distributed Cloud-Lösungen."
     href="https://f5xc-salesdemos.github.io/marketplace/"
+  />
+  <LinkCard
+    icon="f5xc:ai_assistant_logo"
+    title="Konsolen-Katalog"
+    description="Schemagetriebener Katalog von F5 XC-Konsolenrouten, Ressourcen und Browser-Automatisierungsworkflows für KI-gesteuerte UI-Verwaltung."
+    href="https://f5xc-salesdemos.github.io/console/"
   />
 </CardGrid>

--- a/docs/en/index.mdx
+++ b/docs/en/index.mdx
@@ -224,4 +224,10 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     description="AI-powered marketplace for F5 Distributed Cloud solutions."
     href="https://f5xc-salesdemos.github.io/marketplace/"
   />
+  <LinkCard
+    icon="f5xc:ai_assistant_logo"
+    title="Console Catalog"
+    description="Schema-driven catalog of F5 XC console routes, resources, and browser automation workflows for AI-driven UI management."
+    href="https://f5xc-salesdemos.github.io/console/"
+  />
 </CardGrid>

--- a/docs/es/index.mdx
+++ b/docs/es/index.mdx
@@ -14,7 +14,7 @@ hero:
       <img src="/docs/images/hero-platform.svg" alt="F5 Distributed Cloud
       platform" />
 i18n:
-  sourceHash: 29ed36f6adda
+  sourceHash: 72679f3e802e
   translator: machine
 ---
 
@@ -232,5 +232,11 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     title="Marketplace"
     description="Marketplace con tecnología de IA para soluciones de F5 Distributed Cloud."
     href="https://f5xc-salesdemos.github.io/marketplace/"
+  />
+  <LinkCard
+    icon="f5xc:ai_assistant_logo"
+    title="Catálogo de Consola"
+    description="Catálogo basado en esquemas de rutas, recursos y flujos de trabajo de automatización del navegador de la consola F5 XC para la gestión de la interfaz de usuario impulsada por IA."
+    href="https://f5xc-salesdemos.github.io/console/"
   />
 </CardGrid>

--- a/docs/fr/index.mdx
+++ b/docs/fr/index.mdx
@@ -14,7 +14,7 @@ hero:
       <img src="/docs/images/hero-platform.svg" alt="F5 Distributed Cloud
       platform" />
 i18n:
-  sourceHash: 29ed36f6adda
+  sourceHash: 72679f3e802e
   translator: machine
 ---
 
@@ -232,5 +232,11 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     title="Place de marché"
     description="Place de marché alimentée par IA pour les solutions F5 Distributed Cloud."
     href="https://f5xc-salesdemos.github.io/marketplace/"
+  />
+  <LinkCard
+    icon="f5xc:ai_assistant_logo"
+    title="Catalogue Console"
+    description="Catalogue piloté par schéma des routes, ressources et workflows d'automatisation du navigateur de la console F5 XC pour la gestion de l'interface utilisateur pilotée par IA."
+    href="https://f5xc-salesdemos.github.io/console/"
   />
 </CardGrid>

--- a/docs/hi/index.mdx
+++ b/docs/hi/index.mdx
@@ -10,7 +10,7 @@ hero:
       <img src="/docs/images/hero-platform.svg" alt="F5 Distributed Cloud
       platform" />
 i18n:
-  sourceHash: 29ed36f6adda
+  sourceHash: 72679f3e802e
   translator: machine
 ---
 
@@ -228,5 +228,11 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     title="मार्केटप्लेस"
     description="F5 Distributed Cloud समाधानों के लिए AI-संचालित मार्केटप्लेस।"
     href="https://f5xc-salesdemos.github.io/marketplace/"
+  />
+  <LinkCard
+    icon="f5xc:ai_assistant_logo"
+    title="कंसोल कैटलॉग"
+    description="AI-संचालित UI प्रबंधन के लिए F5 XC कंसोल रूट, संसाधनों और ब्राउज़र स्वचालन वर्कफ़्लो का स्कीमा-संचालित कैटलॉग।"
+    href="https://f5xc-salesdemos.github.io/console/"
   />
 </CardGrid>

--- a/docs/it/index.mdx
+++ b/docs/it/index.mdx
@@ -10,7 +10,7 @@ hero:
       <img src="/docs/images/hero-platform.svg" alt="F5 Distributed Cloud
       platform" />
 i18n:
-  sourceHash: 29ed36f6adda
+  sourceHash: 72679f3e802e
   translator: machine
 ---
 
@@ -228,5 +228,11 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     title="Marketplace"
     description="Marketplace basato su IA per le soluzioni F5 Distributed Cloud."
     href="https://f5xc-salesdemos.github.io/marketplace/"
+  />
+  <LinkCard
+    icon="f5xc:ai_assistant_logo"
+    title="Catalogo Console"
+    description="Catalogo basato su schema di route, risorse e flussi di lavoro di automazione del browser della console F5 XC per la gestione dell'interfaccia utente basata su IA."
+    href="https://f5xc-salesdemos.github.io/console/"
   />
 </CardGrid>

--- a/docs/ja/index.mdx
+++ b/docs/ja/index.mdx
@@ -10,7 +10,7 @@ hero:
       <img src="/docs/images/hero-platform.svg" alt="F5 Distributed Cloud
       platform" />
 i18n:
-  sourceHash: 29ed36f6adda
+  sourceHash: 72679f3e802e
   translator: machine
 ---
 
@@ -228,5 +228,11 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     title="マーケットプレイス"
     description="F5 Distributed Cloud ソリューション向けの AI 搭載マーケットプレイス。"
     href="https://f5xc-salesdemos.github.io/marketplace/"
+  />
+  <LinkCard
+    icon="f5xc:ai_assistant_logo"
+    title="コンソールカタログ"
+    description="AI 駆動の UI 管理のための F5 XC コンソールのルート、リソース、およびブラウザ自動化ワークフローのスキーマ駆動カタログ。"
+    href="https://f5xc-salesdemos.github.io/console/"
   />
 </CardGrid>

--- a/docs/ko/index.mdx
+++ b/docs/ko/index.mdx
@@ -10,7 +10,7 @@ hero:
       <img src="/docs/images/hero-platform.svg" alt="F5 Distributed Cloud
       platform" />
 i18n:
-  sourceHash: 29ed36f6adda
+  sourceHash: 72679f3e802e
   translator: machine
 ---
 
@@ -228,5 +228,11 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     title="마켓플레이스"
     description="F5 Distributed Cloud 솔루션을 위한 AI 기반 마켓플레이스."
     href="https://f5xc-salesdemos.github.io/marketplace/"
+  />
+  <LinkCard
+    icon="f5xc:ai_assistant_logo"
+    title="콘솔 카탈로그"
+    description="AI 기반 UI 관리를 위한 F5 XC 콘솔 라우트, 리소스 및 브라우저 자동화 워크플로우의 스키마 기반 카탈로그."
+    href="https://f5xc-salesdemos.github.io/console/"
   />
 </CardGrid>

--- a/docs/llms-federated-sites.json
+++ b/docs/llms-federated-sites.json
@@ -172,5 +172,11 @@
     "url": "https://f5xc-salesdemos.github.io/demo-resources/llms.txt",
     "description": "Catalog of pre-configured Azure VM components for F5 XC demo environments",
     "category": "lab-infrastructure"
+  },
+  {
+    "label": "Console Catalog",
+    "url": "https://f5xc-salesdemos.github.io/console/llms.txt",
+    "description": "Schema-driven inventory of the F5 XC administration console UI — routes, resources, workflows, and browser automation manifests",
+    "category": "developer-tools"
   }
 ]

--- a/docs/pt-br/index.mdx
+++ b/docs/pt-br/index.mdx
@@ -14,7 +14,7 @@ hero:
       <img src="/docs/images/hero-platform.svg" alt="F5 Distributed Cloud
       platform" />
 i18n:
-  sourceHash: 29ed36f6adda
+  sourceHash: 72679f3e802e
   translator: machine
 ---
 
@@ -232,5 +232,11 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     title="Marketplace"
     description="Marketplace com inteligência artificial para soluções F5 Distributed Cloud."
     href="https://f5xc-salesdemos.github.io/marketplace/"
+  />
+  <LinkCard
+    icon="f5xc:ai_assistant_logo"
+    title="Catálogo do Console"
+    description="Catálogo baseado em esquemas de rotas, recursos e fluxos de trabalho de automação do navegador do console F5 XC para gerenciamento de interface de usuário orientado por IA."
+    href="https://f5xc-salesdemos.github.io/console/"
   />
 </CardGrid>

--- a/docs/th/index.mdx
+++ b/docs/th/index.mdx
@@ -10,7 +10,7 @@ hero:
       <img src="/docs/images/hero-platform.svg" alt="F5 Distributed Cloud
       platform" />
 i18n:
-  sourceHash: 29ed36f6adda
+  sourceHash: 72679f3e802e
   translator: machine
 ---
 
@@ -228,5 +228,11 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     title="ตลาดกลาง"
     description="ตลาดกลางที่ขับเคลื่อนด้วย AI สำหรับโซลูชัน F5 Distributed Cloud"
     href="https://f5xc-salesdemos.github.io/marketplace/"
+  />
+  <LinkCard
+    icon="f5xc:ai_assistant_logo"
+    title="แคตตาล็อกคอนโซล"
+    description="แคตตาล็อกที่ขับเคลื่อนด้วยสคีมาของเส้นทาง ทรัพยากร และเวิร์กโฟลว์การทำงานอัตโนมัติของเบราว์เซอร์ในคอนโซล F5 XC สำหรับการจัดการ UI ที่ขับเคลื่อนด้วย AI"
+    href="https://f5xc-salesdemos.github.io/console/"
   />
 </CardGrid>

--- a/docs/zh-cn/index.mdx
+++ b/docs/zh-cn/index.mdx
@@ -10,7 +10,7 @@ hero:
       <img src="/docs/images/hero-platform.svg" alt="F5 Distributed Cloud
       platform" />
 i18n:
-  sourceHash: 29ed36f6adda
+  sourceHash: 72679f3e802e
   translator: machine
 ---
 
@@ -228,5 +228,11 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     title="应用市场"
     description="适用于 F5 分布式云解决方案的 AI 驱动应用市场。"
     href="https://f5xc-salesdemos.github.io/marketplace/"
+  />
+  <LinkCard
+    icon="f5xc:ai_assistant_logo"
+    title="控制台目录"
+    description="用于 AI 驱动 UI 管理的 F5 XC 控制台路由、资源和浏览器自动化工作流的模式驱动目录。"
+    href="https://f5xc-salesdemos.github.io/console/"
   />
 </CardGrid>

--- a/docs/zh-tw/index.mdx
+++ b/docs/zh-tw/index.mdx
@@ -10,7 +10,7 @@ hero:
       <img src="/docs/images/hero-platform.svg" alt="F5 Distributed Cloud
       platform" />
 i18n:
-  sourceHash: 29ed36f6adda
+  sourceHash: 72679f3e802e
   translator: machine
 ---
 
@@ -228,5 +228,11 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     title="應用市集"
     description="適用於 F5 Distributed Cloud 解決方案的 AI 驅動應用市集。"
     href="https://f5xc-salesdemos.github.io/marketplace/"
+  />
+  <LinkCard
+    icon="f5xc:ai_assistant_logo"
+    title="控制台目錄"
+    description="用於 AI 驅動 UI 管理的 F5 XC 控制台路由、資源和瀏覽器自動化工作流程的模式驅動目錄。"
+    href="https://f5xc-salesdemos.github.io/console/"
   />
 </CardGrid>


### PR DESCRIPTION
## Summary

- Added Console Catalog `LinkCard` to the AI section of `docs/en/index.mdx`
- Added console entry to `llms-federated-sites.json` with `developer-tools` category pointing to `https://f5xc-salesdemos.github.io/console/llms.txt`

## Test plan

- [ ] Verify Console Catalog card appears in the AI section of the landing page
- [ ] Verify `llms-federated-sites.json` includes console with correct URL and category

Closes #626

🤖 Generated with [Claude Code](https://claude.com/claude-code)