### PR TITLE
chore: update org name from f5xc-salesdemos to f5-sales-demo

### DIFF
--- a/.claude/governance.json
+++ b/.claude/governance.json
@@ -1,5 +1,5 @@
 {
-  "source_repo": "f5xc-salesdemos/docs-control",
+  "source_repo": "f5-sales-demo/docs-control",
   "skip_files": {
     "xcsh": [
       "biome.json",

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -15,5 +15,5 @@ jobs:
     if: >-
       github.event.pull_request.draft == false &&
       github.actor != 'dependabot[bot]'
-    uses: f5xc-salesdemos/docs-control/.github/workflows/auto-merge.yml@main
+    uses: f5-sales-demo/docs-control/.github/workflows/auto-merge.yml@main
     secrets: inherit

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -10,5 +10,5 @@ permissions:
 jobs:
   call:
     if: github.actor == 'dependabot[bot]'
-    uses: f5xc-salesdemos/docs-control/.github/workflows/dependabot-auto-merge.yml@main
+    uses: f5-sales-demo/docs-control/.github/workflows/dependabot-auto-merge.yml@main
     secrets: inherit

--- a/.github/workflows/enforce-repo-settings.yml
+++ b/.github/workflows/enforce-repo-settings.yml
@@ -25,14 +25,14 @@ concurrency:
 
 jobs:
   enforce-settings:
-    uses: f5xc-salesdemos/docs-control/.github/workflows/enforce-repo-settings.yml@main
+    uses: f5-sales-demo/docs-control/.github/workflows/enforce-repo-settings.yml@main
     with:
       source_sha: ${{ inputs.source_sha || '' }}
     secrets:
       repo-settings-token: ${{ secrets.REPO_SETTINGS_TOKEN }}
 
   sync-files:
-    uses: f5xc-salesdemos/docs-control/.github/workflows/sync-managed-files.yml@main
+    uses: f5-sales-demo/docs-control/.github/workflows/sync-managed-files.yml@main
     with:
       source_sha: ${{ inputs.source_sha || '' }}
     secrets:

--- a/.github/workflows/github-pages-deploy.yml
+++ b/.github/workflows/github-pages-deploy.yml
@@ -19,4 +19,4 @@ concurrency:
 
 jobs:
   docs:
-    uses: f5xc-salesdemos/docs-control/.github/workflows/github-pages-deploy.yml@main
+    uses: f5-sales-demo/docs-control/.github/workflows/github-pages-deploy.yml@main

--- a/.github/workflows/require-linked-issue.yml
+++ b/.github/workflows/require-linked-issue.yml
@@ -15,5 +15,5 @@ concurrency:
 
 jobs:
   check:
-    uses: f5xc-salesdemos/docs-control/.github/workflows/require-linked-issue.yml@main
+    uses: f5-sales-demo/docs-control/.github/workflows/require-linked-issue.yml@main
     secrets: inherit

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -18,5 +18,5 @@ concurrency:
 
 jobs:
   lint:
-    uses: f5xc-salesdemos/docs-control/.github/workflows/super-linter.yml@main
+    uses: f5-sales-demo/docs-control/.github/workflows/super-linter.yml@main
     secrets: inherit

--- a/.github/workflows/translation-audit.yml
+++ b/.github/workflows/translation-audit.yml
@@ -15,4 +15,4 @@ permissions:
 jobs:
   audit:
     # Read-only freshness audit — no secrets required.
-    uses: f5xc-salesdemos/docs-control/.github/workflows/translation-audit.yml@main
+    uses: f5-sales-demo/docs-control/.github/workflows/translation-audit.yml@main

--- a/README.md
+++ b/README.md
@@ -1,29 +1,29 @@
 🌐 English |
-[日本語](https://f5xc-salesdemos.github.io/docs/ja/) |
-[한국어](https://f5xc-salesdemos.github.io/docs/ko/) |
-[简体中文](https://f5xc-salesdemos.github.io/docs/zh-cn/) |
-[繁體中文](https://f5xc-salesdemos.github.io/docs/zh-tw/) |
-[Español](https://f5xc-salesdemos.github.io/docs/es/) |
-[Português](https://f5xc-salesdemos.github.io/docs/pt-br/) |
-[Français](https://f5xc-salesdemos.github.io/docs/fr/) |
-[Deutsch](https://f5xc-salesdemos.github.io/docs/de/) |
-[Italiano](https://f5xc-salesdemos.github.io/docs/it/) |
-[العربية](https://f5xc-salesdemos.github.io/docs/ar/) |
-[हिन्दी](https://f5xc-salesdemos.github.io/docs/hi/) |
-[ไทย](https://f5xc-salesdemos.github.io/docs/th/)
+[日本語](https://f5-sales-demo.github.io/docs/ja/) |
+[한국어](https://f5-sales-demo.github.io/docs/ko/) |
+[简体中文](https://f5-sales-demo.github.io/docs/zh-cn/) |
+[繁體中文](https://f5-sales-demo.github.io/docs/zh-tw/) |
+[Español](https://f5-sales-demo.github.io/docs/es/) |
+[Português](https://f5-sales-demo.github.io/docs/pt-br/) |
+[Français](https://f5-sales-demo.github.io/docs/fr/) |
+[Deutsch](https://f5-sales-demo.github.io/docs/de/) |
+[Italiano](https://f5-sales-demo.github.io/docs/it/) |
+[العربية](https://f5-sales-demo.github.io/docs/ar/) |
+[हिन्दी](https://f5-sales-demo.github.io/docs/hi/) |
+[ไทย](https://f5-sales-demo.github.io/docs/th/)
 
 # F5 XC Docs
 
-[![GitHub Pages Deploy](https://github.com/f5xc-salesdemos/docs/actions/workflows/github-pages-deploy.yml/badge.svg)](https://github.com/f5xc-salesdemos/docs/actions/workflows/github-pages-deploy.yml)
-[![Repository Settings](https://github.com/f5xc-salesdemos/docs/actions/workflows/enforce-repo-settings.yml/badge.svg)](https://github.com/f5xc-salesdemos/docs/actions/workflows/enforce-repo-settings.yml)
-[![License](https://img.shields.io/github/license/f5xc-salesdemos/docs)](LICENSE)
+[![GitHub Pages Deploy](https://github.com/f5-sales-demo/docs/actions/workflows/github-pages-deploy.yml/badge.svg)](https://github.com/f5-sales-demo/docs/actions/workflows/github-pages-deploy.yml)
+[![Repository Settings](https://github.com/f5-sales-demo/docs/actions/workflows/enforce-repo-settings.yml/badge.svg)](https://github.com/f5-sales-demo/docs/actions/workflows/enforce-repo-settings.yml)
+[![License](https://img.shields.io/github/license/f5-sales-demo/docs)](LICENSE)
 
 Organization landing page for F5 Distributed Cloud documentation
 
 
 ## Documentation
 
-Full documentation is available at **[https://f5xc-salesdemos.github.io/docs/](https://f5xc-salesdemos.github.io/docs/)**.
+Full documentation is available at **[https://f5-sales-demo.github.io/docs/](https://f5-sales-demo.github.io/docs/)**.
 
 ## Contributing
 

--- a/docs/ar/index.mdx
+++ b/docs/ar/index.mdx
@@ -15,7 +15,7 @@ i18n:
 ---
 
 import { CardGrid } from '@astrojs/starlight/components';
-import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
+import LinkCard from '@f5-sales-demo/docs-theme/components/LinkCard.astro';
 
 ## حلول الأمان
 
@@ -24,43 +24,43 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     icon="f5xc:web-app-and-api-protection"
     title="WAF"
     description="إعداد جدار حماية تطبيقات الويب (WAF) وسياساته."
-    href="https://f5xc-salesdemos.github.io/waf/"
+    href="https://f5-sales-demo.github.io/waf/"
   />
   <LinkCard
     icon="f5xc:web-app-and-api-protection"
     title="API"
     description="اكتشاف API وحمايته وسياسات الأمان."
-    href="https://f5xc-salesdemos.github.io/api-protection/"
+    href="https://f5-sales-demo.github.io/api-protection/"
   />
   <LinkCard
     icon="f5xc:bot-defense"
     title="Bot Advanced"
     description="دفاع Bot المتقدم مع التحليل السلوكي."
-    href="https://f5xc-salesdemos.github.io/bot-advanced/"
+    href="https://f5-sales-demo.github.io/bot-advanced/"
   />
   <LinkCard
     icon="f5xc:bot-defense"
     title="Bot Standard"
     description="دفاع Bot القياسي مع الكشف المبني على التوقيعات."
-    href="https://f5xc-salesdemos.github.io/bot-standard/"
+    href="https://f5-sales-demo.github.io/bot-standard/"
   />
   <LinkCard
     icon="f5xc:client-side-defense"
     title="CSD"
     description="الدفاع من جهة العميل ضد التهديدات المستندة إلى المتصفح."
-    href="https://f5xc-salesdemos.github.io/csd/"
+    href="https://f5-sales-demo.github.io/csd/"
   />
   <LinkCard
     icon="f5xc:ddos-and-transit-services"
     title="DDoS"
     description="حماية DDoS من هجمات الحرمان من الخدمة الموزعة."
-    href="https://f5xc-salesdemos.github.io/ddos/"
+    href="https://f5-sales-demo.github.io/ddos/"
   />
   <LinkCard
     icon="f5xc:web-app-scanning"
     title="WAS"
     description="فحص تطبيقات الويب وتقييم الثغرات الأمنية."
-    href="https://f5xc-salesdemos.github.io/was/"
+    href="https://f5-sales-demo.github.io/was/"
   />
 </CardGrid>
 
@@ -71,25 +71,25 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     icon="f5xc:multi-cloud-network-connect"
     title="MCN"
     description="الشبكات متعددة السحابات واتصال المواقع."
-    href="https://f5xc-salesdemos.github.io/mcn/"
+    href="https://f5-sales-demo.github.io/mcn/"
   />
   <LinkCard
     icon="f5xc:content-delivery-network"
     title="CDN"
     description="شبكة توصيل المحتوى والتخزين المؤقت على الحافة."
-    href="https://f5xc-salesdemos.github.io/cdn/"
+    href="https://f5-sales-demo.github.io/cdn/"
   />
   <LinkCard
     icon="f5xc:dns-management"
     title="DNS"
     description="إدارة DNS والمناطق وموازنة تحميل DNS."
-    href="https://f5xc-salesdemos.github.io/dns/"
+    href="https://f5-sales-demo.github.io/dns/"
   />
   <LinkCard
     icon="f5xc:nginx-one"
     title="NGINX"
     description="تكامل NGINX وإدارة الإعدادات."
-    href="https://f5xc-salesdemos.github.io/nginx/"
+    href="https://f5-sales-demo.github.io/nginx/"
   />
 </CardGrid>
 
@@ -100,25 +100,25 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     icon="f5xc:distributed-apps"
     title="خادم المصدر"
     description="جهاز VM يعمل بنظام Ubuntu 24.04 مع 9 تطبيقات ويب قابلة للاختراق لاختبار جدار حماية تطبيقات الويب (WAF) وأمان API ودفاع Bot."
-    href="https://f5xc-salesdemos.github.io/origin-server/"
+    href="https://f5-sales-demo.github.io/origin-server/"
   />
   <LinkCard
     icon="f5xc:application-traffic-insight"
     title="مولد حركة المرور"
     description="جهاز VM على Azure مع أكثر من 50 أداة أمان و7 حزم هجوم لتوليد حركة مرور العرض التوضيحي."
-    href="https://f5xc-salesdemos.github.io/traffic-generator/"
+    href="https://f5-sales-demo.github.io/traffic-generator/"
   />
   <LinkCard
     icon="f5xc:content-delivery-network"
     title="محاكي CDN"
     description="محاكي عقدة حافة CDN مبني على NGINX مع أكثر من 67 رأسًا خاصًا بالموردين."
-    href="https://f5xc-salesdemos.github.io/cdn-simulator/"
+    href="https://f5-sales-demo.github.io/cdn-simulator/"
   />
   <LinkCard
     icon="f5xc:platform"
     title="عرض جميع المكونات"
     description="تصفح كتالوج موارد العرض التوضيحي الكامل."
-    href="https://f5xc-salesdemos.github.io/demo-resources/"
+    href="https://f5-sales-demo.github.io/demo-resources/"
   />
 </CardGrid>
 
@@ -129,13 +129,13 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     icon="f5xc:observability"
     title="قابلية المراقبة"
     description="المراقبة والمقاييس ورؤى التطبيقات."
-    href="https://f5xc-salesdemos.github.io/observability/"
+    href="https://f5-sales-demo.github.io/observability/"
   />
   <LinkCard
     icon="f5xc:administration"
     title="الإدارة"
     description="إدارة المستأجرين وصلاحيات RBAC وإعدادات المنصة."
-    href="https://f5xc-salesdemos.github.io/administration/"
+    href="https://f5-sales-demo.github.io/administration/"
   />
 </CardGrid>
 
@@ -146,19 +146,19 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     icon="hashicorp-flight:terraform-color"
     title="موفر Terraform"
     description="موفر Terraform لـ F5 Distributed Cloud."
-    href="https://f5xc-salesdemos.github.io/terraform-provider-f5xc/"
+    href="https://f5-sales-demo.github.io/terraform-provider-f5xc/"
   />
   <LinkCard
     icon="f5xc:data-intelligence"
     title="مواصفات API"
     description="التحقق من صحة مواصفات OpenAPI والتوفيق بينها لـ F5 Distributed Cloud."
-    href="https://f5xc-salesdemos.github.io/api-specs/"
+    href="https://f5-sales-demo.github.io/api-specs/"
   />
   <LinkCard
     icon="f5xc:data-intelligence"
     title="مواصفات API المحسّنة"
     description="مواصفات OpenAPI المحسّنة لـ F5 Distributed Cloud."
-    href="https://f5xc-salesdemos.github.io/api-specs-enriched/"
+    href="https://f5-sales-demo.github.io/api-specs-enriched/"
   />
 </CardGrid>
 
@@ -169,31 +169,31 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     icon="f5xc:doc"
     title="Builder"
     description="نظام بناء توثيق Astro + Starlight المعبّأ في حاويات."
-    href="https://f5xc-salesdemos.github.io/docs-builder/"
+    href="https://f5-sales-demo.github.io/docs-builder/"
   />
   <LinkCard
     icon="f5xc:shared-configuration"
     title="Theme"
     description="العلامة التجارية المشتركة والتنسيق لمواقع التوثيق."
-    href="https://f5xc-salesdemos.github.io/docs-theme/"
+    href="https://f5-sales-demo.github.io/docs-theme/"
   />
   <LinkCard
     icon="f5xc:distributed-apps"
     title="Icons"
     description="حزم أيقونات NPM والمكونات الإضافية لنظام بناء التوثيق."
-    href="https://f5xc-salesdemos.github.io/docs-icons/"
+    href="https://f5-sales-demo.github.io/docs-icons/"
   />
   <LinkCard
     icon="f5xc:shared-configuration"
     title="Control"
     description="سير عمل CI وقوالب الحوكمة وتطبيق إعدادات المستودع."
-    href="https://f5xc-salesdemos.github.io/docs-control/"
+    href="https://f5-sales-demo.github.io/docs-control/"
   />
   <LinkCard
     icon="hashicorp-flight:docker-color"
     title="حاوية التطوير"
     description="بيئة تطوير معزولة مع أدوات البرمجة بالذكاء الاصطناعي."
-    href="https://f5xc-salesdemos.github.io/devcontainer/"
+    href="https://f5-sales-demo.github.io/devcontainer/"
   />
 </CardGrid>
 
@@ -204,19 +204,19 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     icon="f5xc:distributed-apps"
     title="إضافة VS Code"
     description="إدارة موارد F5 XC من VS Code مع IntelliSense ومساعد الدردشة xcsh."
-    href="https://f5xc-salesdemos.github.io/vscode-f5xc-tools/"
+    href="https://f5-sales-demo.github.io/vscode-f5xc-tools/"
   />
   <LinkCard
     icon="f5xc:ai_assistant_logo"
     title="xcsh CLI"
     description="واجهة سطر أوامر مدعومة بالذكاء الاصطناعي لعمليات F5 Distributed Cloud."
-    href="https://f5xc-salesdemos.github.io/xcsh/"
+    href="https://f5-sales-demo.github.io/xcsh/"
   />
   <LinkCard
     icon="f5xc:ai_assistant_logo"
     title="إضافة xcsh لمتصفح Chrome"
     description="تحكم في وحدة تحكم F5 Distributed Cloud باستخدام مساعد xcsh الذكي."
-    href="https://f5xc-salesdemos.github.io/xcsh-chrome-extension/"
+    href="https://f5-sales-demo.github.io/xcsh-chrome-extension/"
   />
 </CardGrid>
 
@@ -227,12 +227,12 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     icon="f5xc:ai_assistant_logo"
     title="السوق"
     description="السوق المدعوم بالذكاء الاصطناعي لحلول F5 Distributed Cloud."
-    href="https://f5xc-salesdemos.github.io/marketplace/"
+    href="https://f5-sales-demo.github.io/marketplace/"
   />
   <LinkCard
     icon="f5xc:ai_assistant_logo"
     title="كتالوج وحدة التحكم"
     description="كتالوج مدفوع بالمخطط لمسارات وحدة تحكم F5 XC والموارد وسير عمل أتمتة المتصفح لإدارة واجهة المستخدم المدفوعة بالذكاء الاصطناعي."
-    href="https://f5xc-salesdemos.github.io/console/"
+    href="https://f5-sales-demo.github.io/console/"
   />
 </CardGrid>

--- a/docs/de/index.mdx
+++ b/docs/de/index.mdx
@@ -15,7 +15,7 @@ i18n:
 ---
 
 import { CardGrid } from '@astrojs/starlight/components';
-import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
+import LinkCard from '@f5-sales-demo/docs-theme/components/LinkCard.astro';
 
 ## Sicherheitslösungen
 
@@ -24,43 +24,43 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     icon="f5xc:web-app-and-api-protection"
     title="WAF"
     description="Konfiguration und Richtlinien für die Web-App-Firewall (WAF)."
-    href="https://f5xc-salesdemos.github.io/waf/"
+    href="https://f5-sales-demo.github.io/waf/"
   />
   <LinkCard
     icon="f5xc:web-app-and-api-protection"
     title="API"
     description="API-Erkennung, -Schutz und Sicherheitsrichtlinien."
-    href="https://f5xc-salesdemos.github.io/api-protection/"
+    href="https://f5-sales-demo.github.io/api-protection/"
   />
   <LinkCard
     icon="f5xc:bot-defense"
     title="Bot Advanced"
     description="Bot-Abwehr erweitert mit Verhaltensanalyse."
-    href="https://f5xc-salesdemos.github.io/bot-advanced/"
+    href="https://f5-sales-demo.github.io/bot-advanced/"
   />
   <LinkCard
     icon="f5xc:bot-defense"
     title="Bot Standard"
     description="Bot-Abwehr Standard mit signaturbasierter Erkennung."
-    href="https://f5xc-salesdemos.github.io/bot-standard/"
+    href="https://f5-sales-demo.github.io/bot-standard/"
   />
   <LinkCard
     icon="f5xc:client-side-defense"
     title="CSD"
     description="Clientseitige Abwehr gegen browserbasierte Bedrohungen."
-    href="https://f5xc-salesdemos.github.io/csd/"
+    href="https://f5-sales-demo.github.io/csd/"
   />
   <LinkCard
     icon="f5xc:ddos-and-transit-services"
     title="DDoS"
     description="DDoS-Schutz gegen verteilte Denial-of-Service-Angriffe."
-    href="https://f5xc-salesdemos.github.io/ddos/"
+    href="https://f5-sales-demo.github.io/ddos/"
   />
   <LinkCard
     icon="f5xc:web-app-scanning"
     title="WAS"
     description="Web-App-Scanning und Schwachstellenbewertung."
-    href="https://f5xc-salesdemos.github.io/was/"
+    href="https://f5-sales-demo.github.io/was/"
   />
 </CardGrid>
 
@@ -71,25 +71,25 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     icon="f5xc:multi-cloud-network-connect"
     title="MCN"
     description="Multi-Cloud-Netzwerk und Site-Konnektivität."
-    href="https://f5xc-salesdemos.github.io/mcn/"
+    href="https://f5-sales-demo.github.io/mcn/"
   />
   <LinkCard
     icon="f5xc:content-delivery-network"
     title="CDN"
     description="Inhaltsbereitstellung und Edge-Caching."
-    href="https://f5xc-salesdemos.github.io/cdn/"
+    href="https://f5-sales-demo.github.io/cdn/"
   />
   <LinkCard
     icon="f5xc:dns-management"
     title="DNS"
     description="DNS-Verwaltung, Zonen und DNS-Lastverteilung."
-    href="https://f5xc-salesdemos.github.io/dns/"
+    href="https://f5-sales-demo.github.io/dns/"
   />
   <LinkCard
     icon="f5xc:nginx-one"
     title="NGINX"
     description="NGINX-Integration und Konfigurationsverwaltung."
-    href="https://f5xc-salesdemos.github.io/nginx/"
+    href="https://f5-sales-demo.github.io/nginx/"
   />
 </CardGrid>
 
@@ -100,25 +100,25 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     icon="f5xc:distributed-apps"
     title="Ursprungsserver"
     description="Ubuntu 24.04 VM mit 9 verwundbaren Webanwendungen für WAF-, API- und Bot-Abwehrtests."
-    href="https://f5xc-salesdemos.github.io/origin-server/"
+    href="https://f5-sales-demo.github.io/origin-server/"
   />
   <LinkCard
     icon="f5xc:application-traffic-insight"
     title="Datenverkehrsgenerator"
     description="Azure VM mit 50+ Sicherheitswerkzeugen und 7 Angriffs-Suites zur Demo-Datenverkehrserzeugung."
-    href="https://f5xc-salesdemos.github.io/traffic-generator/"
+    href="https://f5-sales-demo.github.io/traffic-generator/"
   />
   <LinkCard
     icon="f5xc:content-delivery-network"
     title="CDN-Simulator"
     description="NGINX-basierter CDN-Edge-Node-Simulator mit 67+ anbieterspezifischen Headern."
-    href="https://f5xc-salesdemos.github.io/cdn-simulator/"
+    href="https://f5-sales-demo.github.io/cdn-simulator/"
   />
   <LinkCard
     icon="f5xc:platform"
     title="Alle Komponenten anzeigen"
     description="Den vollständigen Demo-Ressourcen-Katalog durchsuchen."
-    href="https://f5xc-salesdemos.github.io/demo-resources/"
+    href="https://f5-sales-demo.github.io/demo-resources/"
   />
 </CardGrid>
 
@@ -129,13 +129,13 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     icon="f5xc:observability"
     title="Beobachtbarkeit"
     description="Überwachung, Metriken und Anwendungseinblicke."
-    href="https://f5xc-salesdemos.github.io/observability/"
+    href="https://f5-sales-demo.github.io/observability/"
   />
   <LinkCard
     icon="f5xc:administration"
     title="Verwaltung"
     description="Mandantenverwaltung, RBAC und Plattformeinstellungen."
-    href="https://f5xc-salesdemos.github.io/administration/"
+    href="https://f5-sales-demo.github.io/administration/"
   />
 </CardGrid>
 
@@ -146,19 +146,19 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     icon="hashicorp-flight:terraform-color"
     title="Terraform-Provider"
     description="Terraform-Provider für F5 Distributed Cloud."
-    href="https://f5xc-salesdemos.github.io/terraform-provider-f5xc/"
+    href="https://f5-sales-demo.github.io/terraform-provider-f5xc/"
   />
   <LinkCard
     icon="f5xc:data-intelligence"
     title="API-Spezifikationen"
     description="OpenAPI-Spezifikationsvalidierung und -Abstimmung für F5 Distributed Cloud."
-    href="https://f5xc-salesdemos.github.io/api-specs/"
+    href="https://f5-sales-demo.github.io/api-specs/"
   />
   <LinkCard
     icon="f5xc:data-intelligence"
     title="Erweiterte API-Spezifikationen"
     description="Erweiterte OpenAPI-Spezifikationen für F5 Distributed Cloud."
-    href="https://f5xc-salesdemos.github.io/api-specs-enriched/"
+    href="https://f5-sales-demo.github.io/api-specs-enriched/"
   />
 </CardGrid>
 
@@ -169,31 +169,31 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     icon="f5xc:doc"
     title="Builder"
     description="Containerisiertes Astro + Starlight Dokumentations-Build-System."
-    href="https://f5xc-salesdemos.github.io/docs-builder/"
+    href="https://f5-sales-demo.github.io/docs-builder/"
   />
   <LinkCard
     icon="f5xc:shared-configuration"
     title="Theme"
     description="Gemeinsames Branding und Styling für Dokumentationsseiten."
-    href="https://f5xc-salesdemos.github.io/docs-theme/"
+    href="https://f5-sales-demo.github.io/docs-theme/"
   />
   <LinkCard
     icon="f5xc:distributed-apps"
     title="Icons"
     description="NPM-Symbolpakete und Plugins für das Dokumentations-Build-System."
-    href="https://f5xc-salesdemos.github.io/docs-icons/"
+    href="https://f5-sales-demo.github.io/docs-icons/"
   />
   <LinkCard
     icon="f5xc:shared-configuration"
     title="Control"
     description="CI-Workflows, Governance-Vorlagen und Durchsetzung von Repository-Einstellungen."
-    href="https://f5xc-salesdemos.github.io/docs-control/"
+    href="https://f5-sales-demo.github.io/docs-control/"
   />
   <LinkCard
     icon="hashicorp-flight:docker-color"
     title="Entwicklungscontainer"
     description="Isolierte Entwicklungsumgebung mit KI-Programmierwerkzeugen."
-    href="https://f5xc-salesdemos.github.io/devcontainer/"
+    href="https://f5-sales-demo.github.io/devcontainer/"
   />
 </CardGrid>
 
@@ -204,19 +204,19 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     icon="f5xc:distributed-apps"
     title="VS Code Erweiterung"
     description="F5 XC-Ressourcen aus VS Code verwalten mit IntelliSense und xcsh-Chat-Assistent."
-    href="https://f5xc-salesdemos.github.io/vscode-f5xc-tools/"
+    href="https://f5-sales-demo.github.io/vscode-f5xc-tools/"
   />
   <LinkCard
     icon="f5xc:ai_assistant_logo"
     title="xcsh CLI"
     description="KI-gestützte Shell für F5 Distributed Cloud-Operationen."
-    href="https://f5xc-salesdemos.github.io/xcsh/"
+    href="https://f5-sales-demo.github.io/xcsh/"
   />
   <LinkCard
     icon="f5xc:ai_assistant_logo"
     title="xcsh Chrome-Erweiterung"
     description="Steuern Sie die F5 Distributed Cloud-Konsole mit dem xcsh-KI-Assistenten."
-    href="https://f5xc-salesdemos.github.io/xcsh-chrome-extension/"
+    href="https://f5-sales-demo.github.io/xcsh-chrome-extension/"
   />
 </CardGrid>
 
@@ -227,12 +227,12 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     icon="f5xc:ai_assistant_logo"
     title="Marktplatz"
     description="KI-gestützter Marktplatz für F5 Distributed Cloud-Lösungen."
-    href="https://f5xc-salesdemos.github.io/marketplace/"
+    href="https://f5-sales-demo.github.io/marketplace/"
   />
   <LinkCard
     icon="f5xc:ai_assistant_logo"
     title="Konsolen-Katalog"
     description="Schemagetriebener Katalog von F5 XC-Konsolenrouten, Ressourcen und Browser-Automatisierungsworkflows für KI-gesteuerte UI-Verwaltung."
-    href="https://f5xc-salesdemos.github.io/console/"
+    href="https://f5-sales-demo.github.io/console/"
   />
 </CardGrid>

--- a/docs/en/index.mdx
+++ b/docs/en/index.mdx
@@ -10,7 +10,7 @@ hero:
 ---
 
 import { CardGrid } from '@astrojs/starlight/components';
-import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
+import LinkCard from '@f5-sales-demo/docs-theme/components/LinkCard.astro';
 
 ## Security Solutions
 
@@ -19,43 +19,43 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     icon="f5xc:web-app-and-api-protection"
     title="WAF"
     description="Web application firewall configuration and policies."
-    href="https://f5xc-salesdemos.github.io/waf/"
+    href="https://f5-sales-demo.github.io/waf/"
   />
   <LinkCard
     icon="f5xc:web-app-and-api-protection"
     title="API"
     description="API discovery, protection, and security policies."
-    href="https://f5xc-salesdemos.github.io/api-protection/"
+    href="https://f5-sales-demo.github.io/api-protection/"
   />
   <LinkCard
     icon="f5xc:bot-defense"
     title="Bot Advanced"
     description="Advanced bot defense with behavioral analysis."
-    href="https://f5xc-salesdemos.github.io/bot-advanced/"
+    href="https://f5-sales-demo.github.io/bot-advanced/"
   />
   <LinkCard
     icon="f5xc:bot-defense"
     title="Bot Standard"
     description="Standard bot defense with signature-based detection."
-    href="https://f5xc-salesdemos.github.io/bot-standard/"
+    href="https://f5-sales-demo.github.io/bot-standard/"
   />
   <LinkCard
     icon="f5xc:client-side-defense"
     title="CSD"
     description="Client-side defense for browser-based threats."
-    href="https://f5xc-salesdemos.github.io/csd/"
+    href="https://f5-sales-demo.github.io/csd/"
   />
   <LinkCard
     icon="f5xc:ddos-and-transit-services"
     title="DDoS"
     description="Distributed denial-of-service protection."
-    href="https://f5xc-salesdemos.github.io/ddos/"
+    href="https://f5-sales-demo.github.io/ddos/"
   />
   <LinkCard
     icon="f5xc:web-app-scanning"
     title="WAS"
     description="Web application scanning and vulnerability assessment."
-    href="https://f5xc-salesdemos.github.io/was/"
+    href="https://f5-sales-demo.github.io/was/"
   />
 </CardGrid>
 
@@ -66,25 +66,25 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     icon="f5xc:multi-cloud-network-connect"
     title="MCN"
     description="Multi-cloud networking and site connectivity."
-    href="https://f5xc-salesdemos.github.io/mcn/"
+    href="https://f5-sales-demo.github.io/mcn/"
   />
   <LinkCard
     icon="f5xc:content-delivery-network"
     title="CDN"
     description="Content delivery network and edge caching."
-    href="https://f5xc-salesdemos.github.io/cdn/"
+    href="https://f5-sales-demo.github.io/cdn/"
   />
   <LinkCard
     icon="f5xc:dns-management"
     title="DNS"
     description="DNS management, zones, and load balancing."
-    href="https://f5xc-salesdemos.github.io/dns/"
+    href="https://f5-sales-demo.github.io/dns/"
   />
   <LinkCard
     icon="f5xc:nginx-one"
     title="NGINX"
     description="NGINX integration and configuration management."
-    href="https://f5xc-salesdemos.github.io/nginx/"
+    href="https://f5-sales-demo.github.io/nginx/"
   />
 </CardGrid>
 
@@ -95,25 +95,25 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     icon="f5xc:distributed-apps"
     title="Origin Server"
     description="Ubuntu 24.04 VM with 9 vulnerable web applications for WAF, API, and bot defense testing."
-    href="https://f5xc-salesdemos.github.io/origin-server/"
+    href="https://f5-sales-demo.github.io/origin-server/"
   />
   <LinkCard
     icon="f5xc:application-traffic-insight"
     title="Traffic Generator"
     description="Azure VM with 50+ security tools and 7 attack suites for demo traffic generation."
-    href="https://f5xc-salesdemos.github.io/traffic-generator/"
+    href="https://f5-sales-demo.github.io/traffic-generator/"
   />
   <LinkCard
     icon="f5xc:content-delivery-network"
     title="CDN Simulator"
     description="NGINX-based CDN edge node simulator with 67+ vendor-specific headers."
-    href="https://f5xc-salesdemos.github.io/cdn-simulator/"
+    href="https://f5-sales-demo.github.io/cdn-simulator/"
   />
   <LinkCard
     icon="f5xc:platform"
     title="View All Components"
     description="Browse the full demo resource catalog."
-    href="https://f5xc-salesdemos.github.io/demo-resources/"
+    href="https://f5-sales-demo.github.io/demo-resources/"
   />
 </CardGrid>
 
@@ -124,13 +124,13 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     icon="f5xc:observability"
     title="Observability"
     description="Monitoring, metrics, and application insights."
-    href="https://f5xc-salesdemos.github.io/observability/"
+    href="https://f5-sales-demo.github.io/observability/"
   />
   <LinkCard
     icon="f5xc:administration"
     title="Administration"
     description="Tenant management, RBAC, and platform settings."
-    href="https://f5xc-salesdemos.github.io/administration/"
+    href="https://f5-sales-demo.github.io/administration/"
   />
 </CardGrid>
 
@@ -141,19 +141,19 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     icon="hashicorp-flight:terraform-color"
     title="Terraform Provider"
     description="Terraform provider for F5 Distributed Cloud."
-    href="https://f5xc-salesdemos.github.io/terraform-provider-f5xc/"
+    href="https://f5-sales-demo.github.io/terraform-provider-f5xc/"
   />
   <LinkCard
     icon="f5xc:data-intelligence"
     title="API Specs"
     description="OpenAPI spec validation and reconciliation for F5 Distributed Cloud."
-    href="https://f5xc-salesdemos.github.io/api-specs/"
+    href="https://f5-sales-demo.github.io/api-specs/"
   />
   <LinkCard
     icon="f5xc:data-intelligence"
     title="API Specs Enriched"
     description="Enriched OpenAPI specifications for F5 Distributed Cloud."
-    href="https://f5xc-salesdemos.github.io/api-specs-enriched/"
+    href="https://f5-sales-demo.github.io/api-specs-enriched/"
   />
 </CardGrid>
 
@@ -164,31 +164,31 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     icon="f5xc:doc"
     title="Builder"
     description="Containerized Astro + Starlight documentation build system."
-    href="https://f5xc-salesdemos.github.io/docs-builder/"
+    href="https://f5-sales-demo.github.io/docs-builder/"
   />
   <LinkCard
     icon="f5xc:shared-configuration"
     title="Theme"
     description="Shared branding and styling for documentation sites."
-    href="https://f5xc-salesdemos.github.io/docs-theme/"
+    href="https://f5-sales-demo.github.io/docs-theme/"
   />
   <LinkCard
     icon="f5xc:distributed-apps"
     title="Icons"
     description="NPM icon packages and plugins for the documentation build system."
-    href="https://f5xc-salesdemos.github.io/docs-icons/"
+    href="https://f5-sales-demo.github.io/docs-icons/"
   />
   <LinkCard
     icon="f5xc:shared-configuration"
     title="Control"
     description="CI workflows, governance templates, and repo settings enforcement."
-    href="https://f5xc-salesdemos.github.io/docs-control/"
+    href="https://f5-sales-demo.github.io/docs-control/"
   />
   <LinkCard
     icon="hashicorp-flight:docker-color"
     title="Dev Container"
     description="Isolated development environment with AI coding tools."
-    href="https://f5xc-salesdemos.github.io/devcontainer/"
+    href="https://f5-sales-demo.github.io/devcontainer/"
   />
 </CardGrid>
 
@@ -199,19 +199,19 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     icon="f5xc:distributed-apps"
     title="VS Code Extension"
     description="Manage F5 XC resources from VS Code with IntelliSense and xcsh chat assistant."
-    href="https://f5xc-salesdemos.github.io/vscode-f5xc-tools/"
+    href="https://f5-sales-demo.github.io/vscode-f5xc-tools/"
   />
   <LinkCard
     icon="f5xc:ai_assistant_logo"
     title="xcsh CLI"
     description="AI-powered shell for F5 Distributed Cloud operations."
-    href="https://f5xc-salesdemos.github.io/xcsh/"
+    href="https://f5-sales-demo.github.io/xcsh/"
   />
   <LinkCard
     icon="f5xc:ai_assistant_logo"
     title="xcsh Chrome Extension"
     description="Drive the F5 Distributed Cloud console with the xcsh AI assistant."
-    href="https://f5xc-salesdemos.github.io/xcsh-chrome-extension/"
+    href="https://f5-sales-demo.github.io/xcsh-chrome-extension/"
   />
 </CardGrid>
 
@@ -222,12 +222,12 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     icon="f5xc:ai_assistant_logo"
     title="Marketplace"
     description="AI-powered marketplace for F5 Distributed Cloud solutions."
-    href="https://f5xc-salesdemos.github.io/marketplace/"
+    href="https://f5-sales-demo.github.io/marketplace/"
   />
   <LinkCard
     icon="f5xc:ai_assistant_logo"
     title="Console Catalog"
     description="Schema-driven catalog of F5 XC console routes, resources, and browser automation workflows for AI-driven UI management."
-    href="https://f5xc-salesdemos.github.io/console/"
+    href="https://f5-sales-demo.github.io/console/"
   />
 </CardGrid>

--- a/docs/es/index.mdx
+++ b/docs/es/index.mdx
@@ -19,7 +19,7 @@ i18n:
 ---
 
 import { CardGrid } from '@astrojs/starlight/components';
-import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
+import LinkCard from '@f5-sales-demo/docs-theme/components/LinkCard.astro';
 
 ## Soluciones de Seguridad
 
@@ -28,43 +28,43 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     icon="f5xc:web-app-and-api-protection"
     title="WAF"
     description="Configuración y políticas del firewall de aplicaciones web (WAF)."
-    href="https://f5xc-salesdemos.github.io/waf/"
+    href="https://f5-sales-demo.github.io/waf/"
   />
   <LinkCard
     icon="f5xc:web-app-and-api-protection"
     title="API"
     description="Descubrimiento, protección y políticas de seguridad de API."
-    href="https://f5xc-salesdemos.github.io/api-protection/"
+    href="https://f5-sales-demo.github.io/api-protection/"
   />
   <LinkCard
     icon="f5xc:bot-defense"
     title="Bot Advanced"
     description="Defensa Bot avanzada con análisis de comportamiento."
-    href="https://f5xc-salesdemos.github.io/bot-advanced/"
+    href="https://f5-sales-demo.github.io/bot-advanced/"
   />
   <LinkCard
     icon="f5xc:bot-defense"
     title="Bot Standard"
     description="Defensa Bot estándar con detección basada en firmas."
-    href="https://f5xc-salesdemos.github.io/bot-standard/"
+    href="https://f5-sales-demo.github.io/bot-standard/"
   />
   <LinkCard
     icon="f5xc:client-side-defense"
     title="CSD"
     description="Defensa del lado del cliente para amenazas basadas en el navegador."
-    href="https://f5xc-salesdemos.github.io/csd/"
+    href="https://f5-sales-demo.github.io/csd/"
   />
   <LinkCard
     icon="f5xc:ddos-and-transit-services"
     title="DDoS"
     description="Protección DDoS contra ataques de denegación de servicio distribuido."
-    href="https://f5xc-salesdemos.github.io/ddos/"
+    href="https://f5-sales-demo.github.io/ddos/"
   />
   <LinkCard
     icon="f5xc:web-app-scanning"
     title="WAS"
     description="Escaneo de aplicaciones web y evaluación de vulnerabilidades."
-    href="https://f5xc-salesdemos.github.io/was/"
+    href="https://f5-sales-demo.github.io/was/"
   />
 </CardGrid>
 
@@ -75,25 +75,25 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     icon="f5xc:multi-cloud-network-connect"
     title="MCN"
     description="Redes multinube y conectividad de sitios."
-    href="https://f5xc-salesdemos.github.io/mcn/"
+    href="https://f5-sales-demo.github.io/mcn/"
   />
   <LinkCard
     icon="f5xc:content-delivery-network"
     title="CDN"
     description="Red de distribución de contenido y caché en el borde."
-    href="https://f5xc-salesdemos.github.io/cdn/"
+    href="https://f5-sales-demo.github.io/cdn/"
   />
   <LinkCard
     icon="f5xc:dns-management"
     title="DNS"
     description="Gestión de DNS, zonas y balanceo de carga."
-    href="https://f5xc-salesdemos.github.io/dns/"
+    href="https://f5-sales-demo.github.io/dns/"
   />
   <LinkCard
     icon="f5xc:nginx-one"
     title="NGINX"
     description="Integración de NGINX y gestión de configuración."
-    href="https://f5xc-salesdemos.github.io/nginx/"
+    href="https://f5-sales-demo.github.io/nginx/"
   />
 </CardGrid>
 
@@ -104,25 +104,25 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     icon="f5xc:distributed-apps"
     title="Servidor de origen"
     description="VM Ubuntu 24.04 con 9 aplicaciones web vulnerables para pruebas de WAF, API y defensa bot."
-    href="https://f5xc-salesdemos.github.io/origin-server/"
+    href="https://f5-sales-demo.github.io/origin-server/"
   />
   <LinkCard
     icon="f5xc:application-traffic-insight"
     title="Generador de tráfico"
     description="VM de Azure con más de 50 herramientas de seguridad y 7 suites de ataque para la generación de tráfico de demostración."
-    href="https://f5xc-salesdemos.github.io/traffic-generator/"
+    href="https://f5-sales-demo.github.io/traffic-generator/"
   />
   <LinkCard
     icon="f5xc:content-delivery-network"
     title="Simulador CDN"
     description="Simulador de nodo de borde CDN basado en NGINX con más de 67 cabeceras específicas de proveedor."
-    href="https://f5xc-salesdemos.github.io/cdn-simulator/"
+    href="https://f5-sales-demo.github.io/cdn-simulator/"
   />
   <LinkCard
     icon="f5xc:platform"
     title="Ver todos los Componentes"
     description="Explore el catálogo completo de recursos de demostración."
-    href="https://f5xc-salesdemos.github.io/demo-resources/"
+    href="https://f5-sales-demo.github.io/demo-resources/"
   />
 </CardGrid>
 
@@ -133,13 +133,13 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     icon="f5xc:observability"
     title="Observabilidad"
     description="Supervisión, métricas e información sobre aplicaciones."
-    href="https://f5xc-salesdemos.github.io/observability/"
+    href="https://f5-sales-demo.github.io/observability/"
   />
   <LinkCard
     icon="f5xc:administration"
     title="Administración"
     description="Gestión de inquilinos, RBAC y configuración de la Plataforma."
-    href="https://f5xc-salesdemos.github.io/administration/"
+    href="https://f5-sales-demo.github.io/administration/"
   />
 </CardGrid>
 
@@ -150,19 +150,19 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     icon="hashicorp-flight:terraform-color"
     title="Proveedor de Terraform"
     description="Proveedor de Terraform para F5 Distributed Cloud."
-    href="https://f5xc-salesdemos.github.io/terraform-provider-f5xc/"
+    href="https://f5-sales-demo.github.io/terraform-provider-f5xc/"
   />
   <LinkCard
     icon="f5xc:data-intelligence"
     title="Especificaciones de API"
     description="Validación y reconciliación de especificaciones OpenAPI para F5 Distributed Cloud."
-    href="https://f5xc-salesdemos.github.io/api-specs/"
+    href="https://f5-sales-demo.github.io/api-specs/"
   />
   <LinkCard
     icon="f5xc:data-intelligence"
     title="Especificaciones de API enriquecidas"
     description="Especificaciones OpenAPI enriquecidas para F5 Distributed Cloud."
-    href="https://f5xc-salesdemos.github.io/api-specs-enriched/"
+    href="https://f5-sales-demo.github.io/api-specs-enriched/"
   />
 </CardGrid>
 
@@ -173,31 +173,31 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     icon="f5xc:doc"
     title="Constructor"
     description="Sistema de construcción de documentación Astro + Starlight en contenedor."
-    href="https://f5xc-salesdemos.github.io/docs-builder/"
+    href="https://f5-sales-demo.github.io/docs-builder/"
   />
   <LinkCard
     icon="f5xc:shared-configuration"
     title="Tema"
     description="Marca y estilo compartidos para los sitios de documentación."
-    href="https://f5xc-salesdemos.github.io/docs-theme/"
+    href="https://f5-sales-demo.github.io/docs-theme/"
   />
   <LinkCard
     icon="f5xc:distributed-apps"
     title="Iconos"
     description="Paquetes de iconos NPM y complementos para el sistema de construcción de documentación."
-    href="https://f5xc-salesdemos.github.io/docs-icons/"
+    href="https://f5-sales-demo.github.io/docs-icons/"
   />
   <LinkCard
     icon="f5xc:shared-configuration"
     title="Control"
     description="Flujos de trabajo de CI, plantillas de gobernanza y cumplimiento de configuración de repositorios."
-    href="https://f5xc-salesdemos.github.io/docs-control/"
+    href="https://f5-sales-demo.github.io/docs-control/"
   />
   <LinkCard
     icon="hashicorp-flight:docker-color"
     title="Contenedor de desarrollo"
     description="Entorno de desarrollo aislado con herramientas de codificación de IA."
-    href="https://f5xc-salesdemos.github.io/devcontainer/"
+    href="https://f5-sales-demo.github.io/devcontainer/"
   />
 </CardGrid>
 
@@ -208,19 +208,19 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     icon="f5xc:distributed-apps"
     title="VS Code Extensión"
     description="Gestione recursos de F5 XC desde VS Code con IntelliSense y el asistente de chat xcsh."
-    href="https://f5xc-salesdemos.github.io/vscode-f5xc-tools/"
+    href="https://f5-sales-demo.github.io/vscode-f5xc-tools/"
   />
   <LinkCard
     icon="f5xc:ai_assistant_logo"
     title="xcsh CLI"
     description="Shell con tecnología de IA para operaciones de F5 Distributed Cloud."
-    href="https://f5xc-salesdemos.github.io/xcsh/"
+    href="https://f5-sales-demo.github.io/xcsh/"
   />
   <LinkCard
     icon="f5xc:ai_assistant_logo"
     title="Extensión de Chrome xcsh"
     description="Controla la consola de F5 Distributed Cloud con el asistente de IA xcsh."
-    href="https://f5xc-salesdemos.github.io/xcsh-chrome-extension/"
+    href="https://f5-sales-demo.github.io/xcsh-chrome-extension/"
   />
 </CardGrid>
 
@@ -231,12 +231,12 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     icon="f5xc:ai_assistant_logo"
     title="Marketplace"
     description="Marketplace con tecnología de IA para soluciones de F5 Distributed Cloud."
-    href="https://f5xc-salesdemos.github.io/marketplace/"
+    href="https://f5-sales-demo.github.io/marketplace/"
   />
   <LinkCard
     icon="f5xc:ai_assistant_logo"
     title="Catálogo de Consola"
     description="Catálogo basado en esquemas de rutas, recursos y flujos de trabajo de automatización del navegador de la consola F5 XC para la gestión de la interfaz de usuario impulsada por IA."
-    href="https://f5xc-salesdemos.github.io/console/"
+    href="https://f5-sales-demo.github.io/console/"
   />
 </CardGrid>

--- a/docs/fr/index.mdx
+++ b/docs/fr/index.mdx
@@ -19,7 +19,7 @@ i18n:
 ---
 
 import { CardGrid } from '@astrojs/starlight/components';
-import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
+import LinkCard from '@f5-sales-demo/docs-theme/components/LinkCard.astro';
 
 ## Solutions de Sécurité
 
@@ -28,43 +28,43 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     icon="f5xc:web-app-and-api-protection"
     title="WAF"
     description="Configuration et politiques du pare-feu applicatif."
-    href="https://f5xc-salesdemos.github.io/waf/"
+    href="https://f5-sales-demo.github.io/waf/"
   />
   <LinkCard
     icon="f5xc:web-app-and-api-protection"
     title="API"
     description="Découverte des API, protection et politiques de sécurité."
-    href="https://f5xc-salesdemos.github.io/api-protection/"
+    href="https://f5-sales-demo.github.io/api-protection/"
   />
   <LinkCard
     icon="f5xc:bot-defense"
     title="Bot Advanced"
     description="Défense Bot avancée avec analyse comportementale."
-    href="https://f5xc-salesdemos.github.io/bot-advanced/"
+    href="https://f5-sales-demo.github.io/bot-advanced/"
   />
   <LinkCard
     icon="f5xc:bot-defense"
     title="Bot Standard"
     description="Défense Bot standard avec détection basée sur les signatures."
-    href="https://f5xc-salesdemos.github.io/bot-standard/"
+    href="https://f5-sales-demo.github.io/bot-standard/"
   />
   <LinkCard
     icon="f5xc:client-side-defense"
     title="CSD"
     description="Défense côté client contre les menaces basées sur le navigateur."
-    href="https://f5xc-salesdemos.github.io/csd/"
+    href="https://f5-sales-demo.github.io/csd/"
   />
   <LinkCard
     icon="f5xc:ddos-and-transit-services"
     title="DDoS"
     description="Protection contre les attaques par déni de service distribué."
-    href="https://f5xc-salesdemos.github.io/ddos/"
+    href="https://f5-sales-demo.github.io/ddos/"
   />
   <LinkCard
     icon="f5xc:web-app-scanning"
     title="WAS"
     description="Analyse des applications web et évaluation des vulnérabilités."
-    href="https://f5xc-salesdemos.github.io/was/"
+    href="https://f5-sales-demo.github.io/was/"
   />
 </CardGrid>
 
@@ -75,25 +75,25 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     icon="f5xc:multi-cloud-network-connect"
     title="MCN"
     description="Réseau multi-cloud et connectivité des sites."
-    href="https://f5xc-salesdemos.github.io/mcn/"
+    href="https://f5-sales-demo.github.io/mcn/"
   />
   <LinkCard
     icon="f5xc:content-delivery-network"
     title="CDN"
     description="Réseau de distribution de contenu et mise en cache à la périphérie."
-    href="https://f5xc-salesdemos.github.io/cdn/"
+    href="https://f5-sales-demo.github.io/cdn/"
   />
   <LinkCard
     icon="f5xc:dns-management"
     title="DNS"
     description="Gestion DNS, zones et équilibrage de charge DNS."
-    href="https://f5xc-salesdemos.github.io/dns/"
+    href="https://f5-sales-demo.github.io/dns/"
   />
   <LinkCard
     icon="f5xc:nginx-one"
     title="NGINX"
     description="Intégration NGINX et gestion de la configuration."
-    href="https://f5xc-salesdemos.github.io/nginx/"
+    href="https://f5-sales-demo.github.io/nginx/"
   />
 </CardGrid>
 
@@ -104,25 +104,25 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     icon="f5xc:distributed-apps"
     title="Serveur d'origine"
     description="Machine virtuelle Ubuntu 24.04 avec 9 applications web vulnérables pour les tests WAF, API et de défense bot."
-    href="https://f5xc-salesdemos.github.io/origin-server/"
+    href="https://f5-sales-demo.github.io/origin-server/"
   />
   <LinkCard
     icon="f5xc:application-traffic-insight"
     title="Générateur de trafic"
     description="Machine virtuelle Azure avec plus de 50 outils de sécurité et 7 suites d'attaques pour la génération de trafic de démonstration."
-    href="https://f5xc-salesdemos.github.io/traffic-generator/"
+    href="https://f5-sales-demo.github.io/traffic-generator/"
   />
   <LinkCard
     icon="f5xc:content-delivery-network"
     title="Simulateur CDN"
     description="Simulateur de nœud périphérique CDN basé sur NGINX avec plus de 67 en-têtes spécifiques aux fournisseurs."
-    href="https://f5xc-salesdemos.github.io/cdn-simulator/"
+    href="https://f5-sales-demo.github.io/cdn-simulator/"
   />
   <LinkCard
     icon="f5xc:platform"
     title="Voir tous les Composants"
     description="Parcourir le catalogue complet des ressources de démonstration."
-    href="https://f5xc-salesdemos.github.io/demo-resources/"
+    href="https://f5-sales-demo.github.io/demo-resources/"
   />
 </CardGrid>
 
@@ -133,13 +133,13 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     icon="f5xc:observability"
     title="Observabilité"
     description="Surveillance, métriques et informations sur les applications."
-    href="https://f5xc-salesdemos.github.io/observability/"
+    href="https://f5-sales-demo.github.io/observability/"
   />
   <LinkCard
     icon="f5xc:administration"
     title="Administration"
     description="Gestion des locataires, RBAC et paramètres de la plateforme."
-    href="https://f5xc-salesdemos.github.io/administration/"
+    href="https://f5-sales-demo.github.io/administration/"
   />
 </CardGrid>
 
@@ -150,19 +150,19 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     icon="hashicorp-flight:terraform-color"
     title="Fournisseur Terraform"
     description="Fournisseur Terraform pour F5 Distributed Cloud."
-    href="https://f5xc-salesdemos.github.io/terraform-provider-f5xc/"
+    href="https://f5-sales-demo.github.io/terraform-provider-f5xc/"
   />
   <LinkCard
     icon="f5xc:data-intelligence"
     title="Spécifications API"
     description="Validation et réconciliation des spécifications OpenAPI pour F5 Distributed Cloud."
-    href="https://f5xc-salesdemos.github.io/api-specs/"
+    href="https://f5-sales-demo.github.io/api-specs/"
   />
   <LinkCard
     icon="f5xc:data-intelligence"
     title="Spécifications API enrichies"
     description="Spécifications OpenAPI enrichies pour F5 Distributed Cloud."
-    href="https://f5xc-salesdemos.github.io/api-specs-enriched/"
+    href="https://f5-sales-demo.github.io/api-specs-enriched/"
   />
 </CardGrid>
 
@@ -173,31 +173,31 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     icon="f5xc:doc"
     title="Builder"
     description="Système de génération de documentation conteneurisé Astro + Starlight."
-    href="https://f5xc-salesdemos.github.io/docs-builder/"
+    href="https://f5-sales-demo.github.io/docs-builder/"
   />
   <LinkCard
     icon="f5xc:shared-configuration"
     title="Theme"
     description="Image de marque et styles partagés pour les sites de documentation."
-    href="https://f5xc-salesdemos.github.io/docs-theme/"
+    href="https://f5-sales-demo.github.io/docs-theme/"
   />
   <LinkCard
     icon="f5xc:distributed-apps"
     title="Icons"
     description="Paquets d'icônes NPM et plugins pour le système de génération de documentation."
-    href="https://f5xc-salesdemos.github.io/docs-icons/"
+    href="https://f5-sales-demo.github.io/docs-icons/"
   />
   <LinkCard
     icon="f5xc:shared-configuration"
     title="Control"
     description="Workflows CI, modèles de gouvernance et application des paramètres de dépôt."
-    href="https://f5xc-salesdemos.github.io/docs-control/"
+    href="https://f5-sales-demo.github.io/docs-control/"
   />
   <LinkCard
     icon="hashicorp-flight:docker-color"
     title="Conteneur de développement"
     description="Environnement de développement isolé avec des outils de codage IA."
-    href="https://f5xc-salesdemos.github.io/devcontainer/"
+    href="https://f5-sales-demo.github.io/devcontainer/"
   />
 </CardGrid>
 
@@ -208,19 +208,19 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     icon="f5xc:distributed-apps"
     title="Extension VS Code"
     description="Gérez les ressources F5 XC depuis VS Code avec IntelliSense et l'assistant de discussion xcsh."
-    href="https://f5xc-salesdemos.github.io/vscode-f5xc-tools/"
+    href="https://f5-sales-demo.github.io/vscode-f5xc-tools/"
   />
   <LinkCard
     icon="f5xc:ai_assistant_logo"
     title="xcsh CLI"
     description="Interface shell alimentée par IA pour les opérations F5 Distributed Cloud."
-    href="https://f5xc-salesdemos.github.io/xcsh/"
+    href="https://f5-sales-demo.github.io/xcsh/"
   />
   <LinkCard
     icon="f5xc:ai_assistant_logo"
     title="Extension Chrome xcsh"
     description="Pilotez la console F5 Distributed Cloud avec l'assistant IA xcsh."
-    href="https://f5xc-salesdemos.github.io/xcsh-chrome-extension/"
+    href="https://f5-sales-demo.github.io/xcsh-chrome-extension/"
   />
 </CardGrid>
 
@@ -231,12 +231,12 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     icon="f5xc:ai_assistant_logo"
     title="Place de marché"
     description="Place de marché alimentée par IA pour les solutions F5 Distributed Cloud."
-    href="https://f5xc-salesdemos.github.io/marketplace/"
+    href="https://f5-sales-demo.github.io/marketplace/"
   />
   <LinkCard
     icon="f5xc:ai_assistant_logo"
     title="Catalogue Console"
     description="Catalogue piloté par schéma des routes, ressources et workflows d'automatisation du navigateur de la console F5 XC pour la gestion de l'interface utilisateur pilotée par IA."
-    href="https://f5xc-salesdemos.github.io/console/"
+    href="https://f5-sales-demo.github.io/console/"
   />
 </CardGrid>

--- a/docs/hi/index.mdx
+++ b/docs/hi/index.mdx
@@ -15,7 +15,7 @@ i18n:
 ---
 
 import { CardGrid } from '@astrojs/starlight/components';
-import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
+import LinkCard from '@f5-sales-demo/docs-theme/components/LinkCard.astro';
 
 ## सुरक्षा समाधान
 
@@ -24,43 +24,43 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     icon="f5xc:web-app-and-api-protection"
     title="WAF"
     description="वेब एप्लिकेशन फ़ायरवॉल कॉन्फ़िगरेशन और नीतियाँ।"
-    href="https://f5xc-salesdemos.github.io/waf/"
+    href="https://f5-sales-demo.github.io/waf/"
   />
   <LinkCard
     icon="f5xc:web-app-and-api-protection"
     title="API"
     description="API खोज, सुरक्षा, और सुरक्षा नीतियाँ।"
-    href="https://f5xc-salesdemos.github.io/api-protection/"
+    href="https://f5-sales-demo.github.io/api-protection/"
   />
   <LinkCard
     icon="f5xc:bot-defense"
     title="Bot Advanced"
     description="व्यवहार विश्लेषण के साथ Bot उन्नत रक्षा।"
-    href="https://f5xc-salesdemos.github.io/bot-advanced/"
+    href="https://f5-sales-demo.github.io/bot-advanced/"
   />
   <LinkCard
     icon="f5xc:bot-defense"
     title="Bot Standard"
     description="सिग्नेचर-आधारित पहचान के साथ Bot मानक रक्षा।"
-    href="https://f5xc-salesdemos.github.io/bot-standard/"
+    href="https://f5-sales-demo.github.io/bot-standard/"
   />
   <LinkCard
     icon="f5xc:client-side-defense"
     title="CSD"
     description="ब्राउज़र-आधारित खतरों के लिए क्लाइंट-साइड डिफेंस।"
-    href="https://f5xc-salesdemos.github.io/csd/"
+    href="https://f5-sales-demo.github.io/csd/"
   />
   <LinkCard
     icon="f5xc:ddos-and-transit-services"
     title="DDoS"
     description="डिस्ट्रीब्यूटेड डिनायल-ऑफ-सर्विस DDoS सुरक्षा।"
-    href="https://f5xc-salesdemos.github.io/ddos/"
+    href="https://f5-sales-demo.github.io/ddos/"
   />
   <LinkCard
     icon="f5xc:web-app-scanning"
     title="WAS"
     description="वेब ऐप स्कैनिंग और भेद्यता मूल्यांकन।"
-    href="https://f5xc-salesdemos.github.io/was/"
+    href="https://f5-sales-demo.github.io/was/"
   />
 </CardGrid>
 
@@ -71,25 +71,25 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     icon="f5xc:multi-cloud-network-connect"
     title="MCN"
     description="मल्टी-क्लाउड नेटवर्किंग और साइट कनेक्टिविटी।"
-    href="https://f5xc-salesdemos.github.io/mcn/"
+    href="https://f5-sales-demo.github.io/mcn/"
   />
   <LinkCard
     icon="f5xc:content-delivery-network"
     title="CDN"
     description="कंटेंट डिलीवरी नेटवर्क और एज कैशिंग।"
-    href="https://f5xc-salesdemos.github.io/cdn/"
+    href="https://f5-sales-demo.github.io/cdn/"
   />
   <LinkCard
     icon="f5xc:dns-management"
     title="DNS"
     description="DNS प्रबंधन, ज़ोन, और DNS लोड बैलेंसिंग।"
-    href="https://f5xc-salesdemos.github.io/dns/"
+    href="https://f5-sales-demo.github.io/dns/"
   />
   <LinkCard
     icon="f5xc:nginx-one"
     title="NGINX"
     description="NGINX एकीकरण और कॉन्फ़िगरेशन प्रबंधन।"
-    href="https://f5xc-salesdemos.github.io/nginx/"
+    href="https://f5-sales-demo.github.io/nginx/"
   />
 </CardGrid>
 
@@ -100,25 +100,25 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     icon="f5xc:distributed-apps"
     title="ऑरिजिन सर्वर"
     description="WAF, API, और बॉट डिफेंस परीक्षण के लिए 9 कमज़ोर वेब एप्लिकेशन के साथ Ubuntu 24.04 VM।"
-    href="https://f5xc-salesdemos.github.io/origin-server/"
+    href="https://f5-sales-demo.github.io/origin-server/"
   />
   <LinkCard
     icon="f5xc:application-traffic-insight"
     title="ट्रैफ़िक जनरेटर"
     description="डेमो ट्रैफ़िक जनरेशन के लिए 50+ सुरक्षा उपकरण और 7 अटैक सूट के साथ Azure VM।"
-    href="https://f5xc-salesdemos.github.io/traffic-generator/"
+    href="https://f5-sales-demo.github.io/traffic-generator/"
   />
   <LinkCard
     icon="f5xc:content-delivery-network"
     title="CDN सिम्युलेटर"
     description="67+ विक्रेता-विशिष्ट हेडर के साथ NGINX-आधारित CDN एज नोड सिम्युलेटर।"
-    href="https://f5xc-salesdemos.github.io/cdn-simulator/"
+    href="https://f5-sales-demo.github.io/cdn-simulator/"
   />
   <LinkCard
     icon="f5xc:platform"
     title="सभी घटक देखें"
     description="पूर्ण डेमो संसाधन कैटलॉग ब्राउज़ करें।"
-    href="https://f5xc-salesdemos.github.io/demo-resources/"
+    href="https://f5-sales-demo.github.io/demo-resources/"
   />
 </CardGrid>
 
@@ -129,13 +129,13 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     icon="f5xc:observability"
     title="अवलोकनीयता"
     description="निगरानी, मेट्रिक्स, और एप्लिकेशन अंतर्दृष्टि।"
-    href="https://f5xc-salesdemos.github.io/observability/"
+    href="https://f5-sales-demo.github.io/observability/"
   />
   <LinkCard
     icon="f5xc:administration"
     title="प्रशासन"
     description="टेनेंट प्रबंधन, RBAC, और प्लेटफ़ॉर्म सेटिंग्स।"
-    href="https://f5xc-salesdemos.github.io/administration/"
+    href="https://f5-sales-demo.github.io/administration/"
   />
 </CardGrid>
 
@@ -146,19 +146,19 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     icon="hashicorp-flight:terraform-color"
     title="Terraform प्रोवाइडर"
     description="F5 Distributed Cloud के लिए Terraform प्रोवाइडर।"
-    href="https://f5xc-salesdemos.github.io/terraform-provider-f5xc/"
+    href="https://f5-sales-demo.github.io/terraform-provider-f5xc/"
   />
   <LinkCard
     icon="f5xc:data-intelligence"
     title="API विनिर्देश"
     description="F5 Distributed Cloud के लिए OpenAPI स्पेक सत्यापन और सुलह।"
-    href="https://f5xc-salesdemos.github.io/api-specs/"
+    href="https://f5-sales-demo.github.io/api-specs/"
   />
   <LinkCard
     icon="f5xc:data-intelligence"
     title="संवर्धित API विनिर्देश"
     description="F5 Distributed Cloud के लिए संवर्धित OpenAPI विनिर्देश।"
-    href="https://f5xc-salesdemos.github.io/api-specs-enriched/"
+    href="https://f5-sales-demo.github.io/api-specs-enriched/"
   />
 </CardGrid>
 
@@ -169,31 +169,31 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     icon="f5xc:doc"
     title="बिल्डर"
     description="कंटेनरीकृत Astro + Starlight दस्तावेज़ीकरण बिल्ड सिस्टम।"
-    href="https://f5xc-salesdemos.github.io/docs-builder/"
+    href="https://f5-sales-demo.github.io/docs-builder/"
   />
   <LinkCard
     icon="f5xc:shared-configuration"
     title="थीम"
     description="दस्तावेज़ीकरण साइटों के लिए साझा ब्रांडिंग और स्टाइलिंग।"
-    href="https://f5xc-salesdemos.github.io/docs-theme/"
+    href="https://f5-sales-demo.github.io/docs-theme/"
   />
   <LinkCard
     icon="f5xc:distributed-apps"
     title="आइकन"
     description="दस्तावेज़ीकरण बिल्ड सिस्टम के लिए NPM आइकन पैकेज और प्लगइन।"
-    href="https://f5xc-salesdemos.github.io/docs-icons/"
+    href="https://f5-sales-demo.github.io/docs-icons/"
   />
   <LinkCard
     icon="f5xc:shared-configuration"
     title="कंट्रोल"
     description="CI वर्कफ़्लो, गवर्नेंस टेम्पलेट, और रेपो सेटिंग्स प्रवर्तन।"
-    href="https://f5xc-salesdemos.github.io/docs-control/"
+    href="https://f5-sales-demo.github.io/docs-control/"
   />
   <LinkCard
     icon="hashicorp-flight:docker-color"
     title="डेव कंटेनर"
     description="AI कोडिंग उपकरण के साथ पृथक विकास वातावरण।"
-    href="https://f5xc-salesdemos.github.io/devcontainer/"
+    href="https://f5-sales-demo.github.io/devcontainer/"
   />
 </CardGrid>
 
@@ -204,19 +204,19 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     icon="f5xc:distributed-apps"
     title="VS Code एक्सटेंशन"
     description="IntelliSense और xcsh चैट असिस्टेंट के साथ VS Code से F5 XC संसाधन प्रबंधित करें।"
-    href="https://f5xc-salesdemos.github.io/vscode-f5xc-tools/"
+    href="https://f5-sales-demo.github.io/vscode-f5xc-tools/"
   />
   <LinkCard
     icon="f5xc:ai_assistant_logo"
     title="xcsh CLI"
     description="F5 Distributed Cloud संचालन के लिए AI-संचालित शेल।"
-    href="https://f5xc-salesdemos.github.io/xcsh/"
+    href="https://f5-sales-demo.github.io/xcsh/"
   />
   <LinkCard
     icon="f5xc:ai_assistant_logo"
     title="xcsh Chrome एक्सटेंशन"
     description="xcsh AI सहायक के साथ F5 Distributed Cloud कंसोल चलाएं।"
-    href="https://f5xc-salesdemos.github.io/xcsh-chrome-extension/"
+    href="https://f5-sales-demo.github.io/xcsh-chrome-extension/"
   />
 </CardGrid>
 
@@ -227,12 +227,12 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     icon="f5xc:ai_assistant_logo"
     title="मार्केटप्लेस"
     description="F5 Distributed Cloud समाधानों के लिए AI-संचालित मार्केटप्लेस।"
-    href="https://f5xc-salesdemos.github.io/marketplace/"
+    href="https://f5-sales-demo.github.io/marketplace/"
   />
   <LinkCard
     icon="f5xc:ai_assistant_logo"
     title="कंसोल कैटलॉग"
     description="AI-संचालित UI प्रबंधन के लिए F5 XC कंसोल रूट, संसाधनों और ब्राउज़र स्वचालन वर्कफ़्लो का स्कीमा-संचालित कैटलॉग।"
-    href="https://f5xc-salesdemos.github.io/console/"
+    href="https://f5-sales-demo.github.io/console/"
   />
 </CardGrid>

--- a/docs/it/index.mdx
+++ b/docs/it/index.mdx
@@ -15,7 +15,7 @@ i18n:
 ---
 
 import { CardGrid } from '@astrojs/starlight/components';
-import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
+import LinkCard from '@f5-sales-demo/docs-theme/components/LinkCard.astro';
 
 ## Soluzioni di Sicurezza
 
@@ -24,43 +24,43 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     icon="f5xc:web-app-and-api-protection"
     title="WAF"
     description="Configurazione e policy del firewall per applicazioni web."
-    href="https://f5xc-salesdemos.github.io/waf/"
+    href="https://f5-sales-demo.github.io/waf/"
   />
   <LinkCard
     icon="f5xc:web-app-and-api-protection"
     title="API"
     description="Individuazione, protezione e policy di sicurezza delle API."
-    href="https://f5xc-salesdemos.github.io/api-protection/"
+    href="https://f5-sales-demo.github.io/api-protection/"
   />
   <LinkCard
     icon="f5xc:bot-defense"
     title="Bot Advanced"
     description="Difesa Bot avanzata con analisi comportamentale."
-    href="https://f5xc-salesdemos.github.io/bot-advanced/"
+    href="https://f5-sales-demo.github.io/bot-advanced/"
   />
   <LinkCard
     icon="f5xc:bot-defense"
     title="Bot Standard"
     description="Difesa Bot standard con rilevamento basato su firma."
-    href="https://f5xc-salesdemos.github.io/bot-standard/"
+    href="https://f5-sales-demo.github.io/bot-standard/"
   />
   <LinkCard
     icon="f5xc:client-side-defense"
     title="CSD"
     description="Difesa lato client per le minacce basate su browser."
-    href="https://f5xc-salesdemos.github.io/csd/"
+    href="https://f5-sales-demo.github.io/csd/"
   />
   <LinkCard
     icon="f5xc:ddos-and-transit-services"
     title="DDoS"
     description="Protezione DDoS contro gli attacchi di tipo distributed denial-of-service."
-    href="https://f5xc-salesdemos.github.io/ddos/"
+    href="https://f5-sales-demo.github.io/ddos/"
   />
   <LinkCard
     icon="f5xc:web-app-scanning"
     title="WAS"
     description="Scansione delle applicazioni web e valutazione delle vulnerabilità."
-    href="https://f5xc-salesdemos.github.io/was/"
+    href="https://f5-sales-demo.github.io/was/"
   />
 </CardGrid>
 
@@ -71,25 +71,25 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     icon="f5xc:multi-cloud-network-connect"
     title="MCN"
     description="Rete multi-cloud e connettività dei siti."
-    href="https://f5xc-salesdemos.github.io/mcn/"
+    href="https://f5-sales-demo.github.io/mcn/"
   />
   <LinkCard
     icon="f5xc:content-delivery-network"
     title="CDN"
     description="Rete di distribuzione dei contenuti e caching edge."
-    href="https://f5xc-salesdemos.github.io/cdn/"
+    href="https://f5-sales-demo.github.io/cdn/"
   />
   <LinkCard
     icon="f5xc:dns-management"
     title="DNS"
     description="Gestione DNS, zone e bilanciamento del carico."
-    href="https://f5xc-salesdemos.github.io/dns/"
+    href="https://f5-sales-demo.github.io/dns/"
   />
   <LinkCard
     icon="f5xc:nginx-one"
     title="NGINX"
     description="Integrazione NGINX e gestione della configurazione."
-    href="https://f5xc-salesdemos.github.io/nginx/"
+    href="https://f5-sales-demo.github.io/nginx/"
   />
 </CardGrid>
 
@@ -100,25 +100,25 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     icon="f5xc:distributed-apps"
     title="Server di origine"
     description="VM Ubuntu 24.04 con 9 applicazioni web vulnerabili per il test di WAF, API e difesa bot."
-    href="https://f5xc-salesdemos.github.io/origin-server/"
+    href="https://f5-sales-demo.github.io/origin-server/"
   />
   <LinkCard
     icon="f5xc:application-traffic-insight"
     title="Generatore di traffico"
     description="VM Azure con oltre 50 strumenti di sicurezza e 7 suite di attacchi per la generazione di traffico demo."
-    href="https://f5xc-salesdemos.github.io/traffic-generator/"
+    href="https://f5-sales-demo.github.io/traffic-generator/"
   />
   <LinkCard
     icon="f5xc:content-delivery-network"
     title="Simulatore CDN"
     description="Simulatore di nodo edge CDN basato su NGINX con oltre 67 header specifici per fornitore."
-    href="https://f5xc-salesdemos.github.io/cdn-simulator/"
+    href="https://f5-sales-demo.github.io/cdn-simulator/"
   />
   <LinkCard
     icon="f5xc:platform"
     title="Visualizza tutti i Componenti"
     description="Sfoglia il catalogo completo delle risorse demo."
-    href="https://f5xc-salesdemos.github.io/demo-resources/"
+    href="https://f5-sales-demo.github.io/demo-resources/"
   />
 </CardGrid>
 
@@ -129,13 +129,13 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     icon="f5xc:observability"
     title="Osservabilità"
     description="Monitoraggio, metriche e informazioni sulle applicazioni."
-    href="https://f5xc-salesdemos.github.io/observability/"
+    href="https://f5-sales-demo.github.io/observability/"
   />
   <LinkCard
     icon="f5xc:administration"
     title="Amministrazione"
     description="Gestione dei tenant, RBAC e impostazioni della piattaforma."
-    href="https://f5xc-salesdemos.github.io/administration/"
+    href="https://f5-sales-demo.github.io/administration/"
   />
 </CardGrid>
 
@@ -146,19 +146,19 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     icon="hashicorp-flight:terraform-color"
     title="Provider Terraform"
     description="Provider Terraform per F5 Distributed Cloud."
-    href="https://f5xc-salesdemos.github.io/terraform-provider-f5xc/"
+    href="https://f5-sales-demo.github.io/terraform-provider-f5xc/"
   />
   <LinkCard
     icon="f5xc:data-intelligence"
     title="Specifiche API"
     description="Validazione e riconciliazione delle specifiche OpenAPI per F5 Distributed Cloud."
-    href="https://f5xc-salesdemos.github.io/api-specs/"
+    href="https://f5-sales-demo.github.io/api-specs/"
   />
   <LinkCard
     icon="f5xc:data-intelligence"
     title="Specifiche API arricchite"
     description="Specifiche OpenAPI arricchite per F5 Distributed Cloud."
-    href="https://f5xc-salesdemos.github.io/api-specs-enriched/"
+    href="https://f5-sales-demo.github.io/api-specs-enriched/"
   />
 </CardGrid>
 
@@ -169,31 +169,31 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     icon="f5xc:doc"
     title="Builder"
     description="Sistema di build della documentazione containerizzato con Astro + Starlight."
-    href="https://f5xc-salesdemos.github.io/docs-builder/"
+    href="https://f5-sales-demo.github.io/docs-builder/"
   />
   <LinkCard
     icon="f5xc:shared-configuration"
     title="Theme"
     description="Branding e stile condivisi per i siti di documentazione."
-    href="https://f5xc-salesdemos.github.io/docs-theme/"
+    href="https://f5-sales-demo.github.io/docs-theme/"
   />
   <LinkCard
     icon="f5xc:distributed-apps"
     title="Icons"
     description="Pacchetti di icone NPM e plugin per il sistema di build della documentazione."
-    href="https://f5xc-salesdemos.github.io/docs-icons/"
+    href="https://f5-sales-demo.github.io/docs-icons/"
   />
   <LinkCard
     icon="f5xc:shared-configuration"
     title="Control"
     description="Workflow CI, template di governance e applicazione delle impostazioni dei repository."
-    href="https://f5xc-salesdemos.github.io/docs-control/"
+    href="https://f5-sales-demo.github.io/docs-control/"
   />
   <LinkCard
     icon="hashicorp-flight:docker-color"
     title="Contenitore di sviluppo"
     description="Ambiente di sviluppo isolato con strumenti IA per la programmazione."
-    href="https://f5xc-salesdemos.github.io/devcontainer/"
+    href="https://f5-sales-demo.github.io/devcontainer/"
   />
 </CardGrid>
 
@@ -204,19 +204,19 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     icon="f5xc:distributed-apps"
     title="VS Code Estensione"
     description="Gestisci le risorse F5 XC da VS Code con IntelliSense e l'assistente di chat xcsh."
-    href="https://f5xc-salesdemos.github.io/vscode-f5xc-tools/"
+    href="https://f5-sales-demo.github.io/vscode-f5xc-tools/"
   />
   <LinkCard
     icon="f5xc:ai_assistant_logo"
     title="xcsh CLI"
     description="Shell basata su IA per le operazioni di F5 Distributed Cloud."
-    href="https://f5xc-salesdemos.github.io/xcsh/"
+    href="https://f5-sales-demo.github.io/xcsh/"
   />
   <LinkCard
     icon="f5xc:ai_assistant_logo"
     title="Estensione Chrome xcsh"
     description="Controlla la console F5 Distributed Cloud con l'assistente IA xcsh."
-    href="https://f5xc-salesdemos.github.io/xcsh-chrome-extension/"
+    href="https://f5-sales-demo.github.io/xcsh-chrome-extension/"
   />
 </CardGrid>
 
@@ -227,12 +227,12 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     icon="f5xc:ai_assistant_logo"
     title="Marketplace"
     description="Marketplace basato su IA per le soluzioni F5 Distributed Cloud."
-    href="https://f5xc-salesdemos.github.io/marketplace/"
+    href="https://f5-sales-demo.github.io/marketplace/"
   />
   <LinkCard
     icon="f5xc:ai_assistant_logo"
     title="Catalogo Console"
     description="Catalogo basato su schema di route, risorse e flussi di lavoro di automazione del browser della console F5 XC per la gestione dell'interfaccia utente basata su IA."
-    href="https://f5xc-salesdemos.github.io/console/"
+    href="https://f5-sales-demo.github.io/console/"
   />
 </CardGrid>

--- a/docs/ja/index.mdx
+++ b/docs/ja/index.mdx
@@ -15,7 +15,7 @@ i18n:
 ---
 
 import { CardGrid } from '@astrojs/starlight/components';
-import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
+import LinkCard from '@f5-sales-demo/docs-theme/components/LinkCard.astro';
 
 ## セキュリティソリューション
 
@@ -24,43 +24,43 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     icon="f5xc:web-app-and-api-protection"
     title="WAF"
     description="Web アプリファイアウォール (WAF) の設定とポリシー。"
-    href="https://f5xc-salesdemos.github.io/waf/"
+    href="https://f5-sales-demo.github.io/waf/"
   />
   <LinkCard
     icon="f5xc:web-app-and-api-protection"
     title="API"
     description="API の検出、保護、およびセキュリティポリシー。"
-    href="https://f5xc-salesdemos.github.io/api-protection/"
+    href="https://f5-sales-demo.github.io/api-protection/"
   />
   <LinkCard
     icon="f5xc:bot-defense"
     title="Bot Advanced"
     description="行動分析による Bot 高度防御。"
-    href="https://f5xc-salesdemos.github.io/bot-advanced/"
+    href="https://f5-sales-demo.github.io/bot-advanced/"
   />
   <LinkCard
     icon="f5xc:bot-defense"
     title="Bot Standard"
     description="シグネチャベースの検出による Bot 標準防御。"
-    href="https://f5xc-salesdemos.github.io/bot-standard/"
+    href="https://f5-sales-demo.github.io/bot-standard/"
   />
   <LinkCard
     icon="f5xc:client-side-defense"
     title="CSD"
     description="ブラウザベースの脅威に対するクライアントサイド防御。"
-    href="https://f5xc-salesdemos.github.io/csd/"
+    href="https://f5-sales-demo.github.io/csd/"
   />
   <LinkCard
     icon="f5xc:ddos-and-transit-services"
     title="DDoS"
     description="分散型サービス拒否攻撃に対する DDoS 対策。"
-    href="https://f5xc-salesdemos.github.io/ddos/"
+    href="https://f5-sales-demo.github.io/ddos/"
   />
   <LinkCard
     icon="f5xc:web-app-scanning"
     title="WAS"
     description="Web アプリスキャンおよび脆弱性評価。"
-    href="https://f5xc-salesdemos.github.io/was/"
+    href="https://f5-sales-demo.github.io/was/"
   />
 </CardGrid>
 
@@ -71,25 +71,25 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     icon="f5xc:multi-cloud-network-connect"
     title="MCN"
     description="マルチクラウドネットワークおよびサイト接続。"
-    href="https://f5xc-salesdemos.github.io/mcn/"
+    href="https://f5-sales-demo.github.io/mcn/"
   />
   <LinkCard
     icon="f5xc:content-delivery-network"
     title="CDN"
     description="コンテンツ配信ネットワークおよびエッジキャッシング。"
-    href="https://f5xc-salesdemos.github.io/cdn/"
+    href="https://f5-sales-demo.github.io/cdn/"
   />
   <LinkCard
     icon="f5xc:dns-management"
     title="DNS"
     description="DNS 管理、ゾーン、および DNS ロードバランシング。"
-    href="https://f5xc-salesdemos.github.io/dns/"
+    href="https://f5-sales-demo.github.io/dns/"
   />
   <LinkCard
     icon="f5xc:nginx-one"
     title="NGINX"
     description="NGINX インテグレーションおよび構成管理。"
-    href="https://f5xc-salesdemos.github.io/nginx/"
+    href="https://f5-sales-demo.github.io/nginx/"
   />
 </CardGrid>
 
@@ -100,25 +100,25 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     icon="f5xc:distributed-apps"
     title="オリジンサーバー"
     description="WAF、API、および Bot 防御テスト用の脆弱な Web アプリケーションを 9 種類搭載した Ubuntu 24.04 VM。"
-    href="https://f5xc-salesdemos.github.io/origin-server/"
+    href="https://f5-sales-demo.github.io/origin-server/"
   />
   <LinkCard
     icon="f5xc:application-traffic-insight"
     title="トラフィックジェネレーター"
     description="デモトラフィック生成用の 50 以上のセキュリティツールと 7 つの攻撃スイートを備えた Azure VM。"
-    href="https://f5xc-salesdemos.github.io/traffic-generator/"
+    href="https://f5-sales-demo.github.io/traffic-generator/"
   />
   <LinkCard
     icon="f5xc:content-delivery-network"
     title="CDN シミュレーター"
     description="67 以上のベンダー固有ヘッダーを持つ NGINX ベースの CDN エッジノードシミュレーター。"
-    href="https://f5xc-salesdemos.github.io/cdn-simulator/"
+    href="https://f5-sales-demo.github.io/cdn-simulator/"
   />
   <LinkCard
     icon="f5xc:platform"
     title="すべてのコンポーネントを表示"
     description="デモリソースの完全なカタログを参照する。"
-    href="https://f5xc-salesdemos.github.io/demo-resources/"
+    href="https://f5-sales-demo.github.io/demo-resources/"
   />
 </CardGrid>
 
@@ -129,13 +129,13 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     icon="f5xc:observability"
     title="オブザーバビリティ"
     description="モニタリング、メトリクス、およびアプリケーションインサイト。"
-    href="https://f5xc-salesdemos.github.io/observability/"
+    href="https://f5-sales-demo.github.io/observability/"
   />
   <LinkCard
     icon="f5xc:administration"
     title="管理"
     description="テナント管理、RBAC、およびプラットフォーム設定。"
-    href="https://f5xc-salesdemos.github.io/administration/"
+    href="https://f5-sales-demo.github.io/administration/"
   />
 </CardGrid>
 
@@ -146,19 +146,19 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     icon="hashicorp-flight:terraform-color"
     title="Terraform プロバイダー"
     description="F5 Distributed Cloud 向け Terraform プロバイダー。"
-    href="https://f5xc-salesdemos.github.io/terraform-provider-f5xc/"
+    href="https://f5-sales-demo.github.io/terraform-provider-f5xc/"
   />
   <LinkCard
     icon="f5xc:data-intelligence"
     title="API 仕様"
     description="F5 Distributed Cloud 向け OpenAPI 仕様の検証と照合。"
-    href="https://f5xc-salesdemos.github.io/api-specs/"
+    href="https://f5-sales-demo.github.io/api-specs/"
   />
   <LinkCard
     icon="f5xc:data-intelligence"
     title="拡充 API 仕様"
     description="F5 Distributed Cloud 向けの拡充 OpenAPI 仕様。"
-    href="https://f5xc-salesdemos.github.io/api-specs-enriched/"
+    href="https://f5-sales-demo.github.io/api-specs-enriched/"
   />
 </CardGrid>
 
@@ -169,31 +169,31 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     icon="f5xc:doc"
     title="Builder"
     description="コンテナ化された Astro + Starlight ドキュメントビルドシステム。"
-    href="https://f5xc-salesdemos.github.io/docs-builder/"
+    href="https://f5-sales-demo.github.io/docs-builder/"
   />
   <LinkCard
     icon="f5xc:shared-configuration"
     title="Theme"
     description="ドキュメントサイト向けの共有ブランディングおよびスタイリング。"
-    href="https://f5xc-salesdemos.github.io/docs-theme/"
+    href="https://f5-sales-demo.github.io/docs-theme/"
   />
   <LinkCard
     icon="f5xc:distributed-apps"
     title="Icons"
     description="ドキュメントビルドシステム向けの NPM アイコンパッケージおよびプラグイン。"
-    href="https://f5xc-salesdemos.github.io/docs-icons/"
+    href="https://f5-sales-demo.github.io/docs-icons/"
   />
   <LinkCard
     icon="f5xc:shared-configuration"
     title="Control"
     description="CI ワークフロー、ガバナンステンプレート、およびリポジトリ設定の適用。"
-    href="https://f5xc-salesdemos.github.io/docs-control/"
+    href="https://f5-sales-demo.github.io/docs-control/"
   />
   <LinkCard
     icon="hashicorp-flight:docker-color"
     title="開発コンテナ"
     description="AI コーディングツールを搭載した隔離された開発環境。"
-    href="https://f5xc-salesdemos.github.io/devcontainer/"
+    href="https://f5-sales-demo.github.io/devcontainer/"
   />
 </CardGrid>
 
@@ -204,19 +204,19 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     icon="f5xc:distributed-apps"
     title="VS Code 拡張機能"
     description="IntelliSense および xcsh チャットアシスタントを使用して VS Code から F5 XC リソースを管理する。"
-    href="https://f5xc-salesdemos.github.io/vscode-f5xc-tools/"
+    href="https://f5-sales-demo.github.io/vscode-f5xc-tools/"
   />
   <LinkCard
     icon="f5xc:ai_assistant_logo"
     title="xcsh CLI"
     description="F5 Distributed Cloud オペレーション向けの AI 搭載シェル。"
-    href="https://f5xc-salesdemos.github.io/xcsh/"
+    href="https://f5-sales-demo.github.io/xcsh/"
   />
   <LinkCard
     icon="f5xc:ai_assistant_logo"
     title="xcsh Chrome 拡張機能"
     description="xcsh AI アシスタントで F5 Distributed Cloud コンソールを操作。"
-    href="https://f5xc-salesdemos.github.io/xcsh-chrome-extension/"
+    href="https://f5-sales-demo.github.io/xcsh-chrome-extension/"
   />
 </CardGrid>
 
@@ -227,12 +227,12 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     icon="f5xc:ai_assistant_logo"
     title="マーケットプレイス"
     description="F5 Distributed Cloud ソリューション向けの AI 搭載マーケットプレイス。"
-    href="https://f5xc-salesdemos.github.io/marketplace/"
+    href="https://f5-sales-demo.github.io/marketplace/"
   />
   <LinkCard
     icon="f5xc:ai_assistant_logo"
     title="コンソールカタログ"
     description="AI 駆動の UI 管理のための F5 XC コンソールのルート、リソース、およびブラウザ自動化ワークフローのスキーマ駆動カタログ。"
-    href="https://f5xc-salesdemos.github.io/console/"
+    href="https://f5-sales-demo.github.io/console/"
   />
 </CardGrid>

--- a/docs/ko/index.mdx
+++ b/docs/ko/index.mdx
@@ -15,7 +15,7 @@ i18n:
 ---
 
 import { CardGrid } from '@astrojs/starlight/components';
-import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
+import LinkCard from '@f5-sales-demo/docs-theme/components/LinkCard.astro';
 
 ## 보안 솔루션
 
@@ -24,43 +24,43 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     icon="f5xc:web-app-and-api-protection"
     title="WAF"
     description="웹 애플리케이션 방화벽 구성 및 정책."
-    href="https://f5xc-salesdemos.github.io/waf/"
+    href="https://f5-sales-demo.github.io/waf/"
   />
   <LinkCard
     icon="f5xc:web-app-and-api-protection"
     title="API"
     description="API 검색, 보호 및 보안 정책."
-    href="https://f5xc-salesdemos.github.io/api-protection/"
+    href="https://f5-sales-demo.github.io/api-protection/"
   />
   <LinkCard
     icon="f5xc:bot-defense"
     title="Bot Advanced"
     description="행동 분석을 통한 고급 봇 방어."
-    href="https://f5xc-salesdemos.github.io/bot-advanced/"
+    href="https://f5-sales-demo.github.io/bot-advanced/"
   />
   <LinkCard
     icon="f5xc:bot-defense"
     title="Bot Standard"
     description="시그니처 기반 탐지를 통한 표준 봇 방어."
-    href="https://f5xc-salesdemos.github.io/bot-standard/"
+    href="https://f5-sales-demo.github.io/bot-standard/"
   />
   <LinkCard
     icon="f5xc:client-side-defense"
     title="CSD"
     description="브라우저 기반 위협에 대한 클라이언트 측 방어."
-    href="https://f5xc-salesdemos.github.io/csd/"
+    href="https://f5-sales-demo.github.io/csd/"
   />
   <LinkCard
     icon="f5xc:ddos-and-transit-services"
     title="DDoS"
     description="분산 서비스 거부 공격 보호."
-    href="https://f5xc-salesdemos.github.io/ddos/"
+    href="https://f5-sales-demo.github.io/ddos/"
   />
   <LinkCard
     icon="f5xc:web-app-scanning"
     title="WAS"
     description="웹 애플리케이션 스캐닝 및 취약점 평가."
-    href="https://f5xc-salesdemos.github.io/was/"
+    href="https://f5-sales-demo.github.io/was/"
   />
 </CardGrid>
 
@@ -71,25 +71,25 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     icon="f5xc:multi-cloud-network-connect"
     title="MCN"
     description="멀티클라우드 네트워킹 및 사이트 연결."
-    href="https://f5xc-salesdemos.github.io/mcn/"
+    href="https://f5-sales-demo.github.io/mcn/"
   />
   <LinkCard
     icon="f5xc:content-delivery-network"
     title="CDN"
     description="콘텐츠 전달 네트워크 및 엣지 캐싱."
-    href="https://f5xc-salesdemos.github.io/cdn/"
+    href="https://f5-sales-demo.github.io/cdn/"
   />
   <LinkCard
     icon="f5xc:dns-management"
     title="DNS"
     description="DNS 관리, 영역 및 부하 분산."
-    href="https://f5xc-salesdemos.github.io/dns/"
+    href="https://f5-sales-demo.github.io/dns/"
   />
   <LinkCard
     icon="f5xc:nginx-one"
     title="NGINX"
     description="NGINX 통합 및 구성 관리."
-    href="https://f5xc-salesdemos.github.io/nginx/"
+    href="https://f5-sales-demo.github.io/nginx/"
   />
 </CardGrid>
 
@@ -100,25 +100,25 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     icon="f5xc:distributed-apps"
     title="오리진 서버"
     description="WAF, API 및 봇 방어 테스트를 위한 9개의 취약한 웹 애플리케이션이 포함된 Ubuntu 24.04 VM."
-    href="https://f5xc-salesdemos.github.io/origin-server/"
+    href="https://f5-sales-demo.github.io/origin-server/"
   />
   <LinkCard
     icon="f5xc:application-traffic-insight"
     title="트래픽 생성기"
     description="데모 트래픽 생성을 위한 50개 이상의 보안 도구 및 7개의 공격 스위트가 포함된 Azure VM."
-    href="https://f5xc-salesdemos.github.io/traffic-generator/"
+    href="https://f5-sales-demo.github.io/traffic-generator/"
   />
   <LinkCard
     icon="f5xc:content-delivery-network"
     title="CDN 시뮬레이터"
     description="67개 이상의 벤더별 헤더를 지원하는 NGINX 기반 CDN 엣지 노드 시뮬레이터."
-    href="https://f5xc-salesdemos.github.io/cdn-simulator/"
+    href="https://f5-sales-demo.github.io/cdn-simulator/"
   />
   <LinkCard
     icon="f5xc:platform"
     title="모든 구성 요소 보기"
     description="전체 데모 리소스 카탈로그를 탐색합니다."
-    href="https://f5xc-salesdemos.github.io/demo-resources/"
+    href="https://f5-sales-demo.github.io/demo-resources/"
   />
 </CardGrid>
 
@@ -129,13 +129,13 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     icon="f5xc:observability"
     title="관측 가능성"
     description="모니터링, 메트릭 및 애플리케이션 인사이트."
-    href="https://f5xc-salesdemos.github.io/observability/"
+    href="https://f5-sales-demo.github.io/observability/"
   />
   <LinkCard
     icon="f5xc:administration"
     title="관리"
     description="테넌트 관리, RBAC 및 플랫폼 설정."
-    href="https://f5xc-salesdemos.github.io/administration/"
+    href="https://f5-sales-demo.github.io/administration/"
   />
 </CardGrid>
 
@@ -146,19 +146,19 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     icon="hashicorp-flight:terraform-color"
     title="Terraform 프로바이더"
     description="F5 Distributed Cloud용 Terraform 프로바이더."
-    href="https://f5xc-salesdemos.github.io/terraform-provider-f5xc/"
+    href="https://f5-sales-demo.github.io/terraform-provider-f5xc/"
   />
   <LinkCard
     icon="f5xc:data-intelligence"
     title="API 사양"
     description="F5 Distributed Cloud를 위한 OpenAPI 사양 유효성 검사 및 조정."
-    href="https://f5xc-salesdemos.github.io/api-specs/"
+    href="https://f5-sales-demo.github.io/api-specs/"
   />
   <LinkCard
     icon="f5xc:data-intelligence"
     title="강화된 API 사양"
     description="F5 Distributed Cloud를 위한 강화된 OpenAPI 사양."
-    href="https://f5xc-salesdemos.github.io/api-specs-enriched/"
+    href="https://f5-sales-demo.github.io/api-specs-enriched/"
   />
 </CardGrid>
 
@@ -169,31 +169,31 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     icon="f5xc:doc"
     title="빌더"
     description="컨테이너화된 Astro + Starlight 문서 빌드 시스템."
-    href="https://f5xc-salesdemos.github.io/docs-builder/"
+    href="https://f5-sales-demo.github.io/docs-builder/"
   />
   <LinkCard
     icon="f5xc:shared-configuration"
     title="테마"
     description="문서 사이트를 위한 공유 브랜딩 및 스타일링."
-    href="https://f5xc-salesdemos.github.io/docs-theme/"
+    href="https://f5-sales-demo.github.io/docs-theme/"
   />
   <LinkCard
     icon="f5xc:distributed-apps"
     title="아이콘"
     description="문서 빌드 시스템을 위한 NPM 아이콘 패키지 및 플러그인."
-    href="https://f5xc-salesdemos.github.io/docs-icons/"
+    href="https://f5-sales-demo.github.io/docs-icons/"
   />
   <LinkCard
     icon="f5xc:shared-configuration"
     title="컨트롤"
     description="CI 워크플로우, 거버넌스 템플릿 및 리포지토리 설정 적용."
-    href="https://f5xc-salesdemos.github.io/docs-control/"
+    href="https://f5-sales-demo.github.io/docs-control/"
   />
   <LinkCard
     icon="hashicorp-flight:docker-color"
     title="개발 컨테이너"
     description="AI 코딩 도구가 포함된 격리된 개발 환경."
-    href="https://f5xc-salesdemos.github.io/devcontainer/"
+    href="https://f5-sales-demo.github.io/devcontainer/"
   />
 </CardGrid>
 
@@ -204,19 +204,19 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     icon="f5xc:distributed-apps"
     title="VS Code 확장"
     description="IntelliSense 및 xcsh 채팅 어시스턴트를 통해 VS Code에서 F5 XC 리소스를 관리합니다."
-    href="https://f5xc-salesdemos.github.io/vscode-f5xc-tools/"
+    href="https://f5-sales-demo.github.io/vscode-f5xc-tools/"
   />
   <LinkCard
     icon="f5xc:ai_assistant_logo"
     title="xcsh CLI"
     description="F5 Distributed Cloud 운영을 위한 AI 기반 셸."
-    href="https://f5xc-salesdemos.github.io/xcsh/"
+    href="https://f5-sales-demo.github.io/xcsh/"
   />
   <LinkCard
     icon="f5xc:ai_assistant_logo"
     title="xcsh Chrome 확장"
     description="xcsh AI 어시스턴트로 F5 Distributed Cloud 콘솔을 제어하세요."
-    href="https://f5xc-salesdemos.github.io/xcsh-chrome-extension/"
+    href="https://f5-sales-demo.github.io/xcsh-chrome-extension/"
   />
 </CardGrid>
 
@@ -227,12 +227,12 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     icon="f5xc:ai_assistant_logo"
     title="마켓플레이스"
     description="F5 Distributed Cloud 솔루션을 위한 AI 기반 마켓플레이스."
-    href="https://f5xc-salesdemos.github.io/marketplace/"
+    href="https://f5-sales-demo.github.io/marketplace/"
   />
   <LinkCard
     icon="f5xc:ai_assistant_logo"
     title="콘솔 카탈로그"
     description="AI 기반 UI 관리를 위한 F5 XC 콘솔 라우트, 리소스 및 브라우저 자동화 워크플로우의 스키마 기반 카탈로그."
-    href="https://f5xc-salesdemos.github.io/console/"
+    href="https://f5-sales-demo.github.io/console/"
   />
 </CardGrid>

--- a/docs/llms-federated-sites.json
+++ b/docs/llms-federated-sites.json
@@ -1,181 +1,181 @@
 [
   {
     "label": "f5xc Docs Builder",
-    "url": "https://f5xc-salesdemos.github.io/docs-builder/llms.txt",
+    "url": "https://f5-sales-demo.github.io/docs-builder/llms.txt",
     "description": "Containerized Astro + Starlight documentation build system",
     "category": "build-platform"
   },
   {
     "label": "XC Docs Theme",
-    "url": "https://f5xc-salesdemos.github.io/docs-theme/llms.txt",
+    "url": "https://f5-sales-demo.github.io/docs-theme/llms.txt",
     "description": "Shared branding and styling for F5 Distributed Cloud documentation sites",
     "category": "build-platform"
   },
   {
     "label": "F5 XC Docs",
-    "url": "https://f5xc-salesdemos.github.io/docs/llms.txt",
+    "url": "https://f5-sales-demo.github.io/docs/llms.txt",
     "description": "Organization landing page for F5 Distributed Cloud documentation",
     "category": "portal"
   },
   {
     "label": "Administration",
-    "url": "https://f5xc-salesdemos.github.io/administration/llms.txt",
+    "url": "https://f5-sales-demo.github.io/administration/llms.txt",
     "description": "F5 XC administration and tenant management",
     "category": "product-features"
   },
   {
     "label": "NGINX",
-    "url": "https://f5xc-salesdemos.github.io/nginx/llms.txt",
+    "url": "https://f5-sales-demo.github.io/nginx/llms.txt",
     "description": "F5 XC NGINX integration and configuration",
     "category": "product-features"
   },
   {
     "label": "Observability",
-    "url": "https://f5xc-salesdemos.github.io/observability/llms.txt",
+    "url": "https://f5-sales-demo.github.io/observability/llms.txt",
     "description": "F5 XC observability and monitoring",
     "category": "product-features"
   },
   {
     "label": "Web App Scanning",
-    "url": "https://f5xc-salesdemos.github.io/was/llms.txt",
+    "url": "https://f5-sales-demo.github.io/was/llms.txt",
     "description": "F5 XC web application scanning",
     "category": "product-features"
   },
   {
     "label": "Multi-Cloud Networking",
-    "url": "https://f5xc-salesdemos.github.io/mcn/llms.txt",
+    "url": "https://f5-sales-demo.github.io/mcn/llms.txt",
     "description": "F5 XC multi-cloud networking",
     "category": "product-features"
   },
   {
     "label": "DNS",
-    "url": "https://f5xc-salesdemos.github.io/dns/llms.txt",
+    "url": "https://f5-sales-demo.github.io/dns/llms.txt",
     "description": "F5 XC DNS management",
     "category": "product-features"
   },
   {
     "label": "CDN",
-    "url": "https://f5xc-salesdemos.github.io/cdn/llms.txt",
+    "url": "https://f5-sales-demo.github.io/cdn/llms.txt",
     "description": "F5 XC content delivery network",
     "category": "product-features"
   },
   {
     "label": "Bot Standard",
-    "url": "https://f5xc-salesdemos.github.io/bot-standard/llms.txt",
+    "url": "https://f5-sales-demo.github.io/bot-standard/llms.txt",
     "description": "F5 XC standard bot defense",
     "category": "product-features"
   },
   {
     "label": "Bot Advanced",
-    "url": "https://f5xc-salesdemos.github.io/bot-advanced/llms.txt",
+    "url": "https://f5-sales-demo.github.io/bot-advanced/llms.txt",
     "description": "F5 XC advanced bot defense",
     "category": "product-features"
   },
   {
     "label": "DDoS",
-    "url": "https://f5xc-salesdemos.github.io/ddos/llms.txt",
+    "url": "https://f5-sales-demo.github.io/ddos/llms.txt",
     "description": "F5 XC DDoS protection",
     "category": "product-features"
   },
   {
     "label": "WAF",
-    "url": "https://f5xc-salesdemos.github.io/waf/llms.txt",
+    "url": "https://f5-sales-demo.github.io/waf/llms.txt",
     "description": "F5 XC web application firewall",
     "category": "product-features"
   },
   {
     "label": "API Security",
-    "url": "https://f5xc-salesdemos.github.io/api-protection/llms.txt",
+    "url": "https://f5-sales-demo.github.io/api-protection/llms.txt",
     "description": "F5 XC API security",
     "category": "product-features"
   },
   {
     "label": "API Specs",
-    "url": "https://f5xc-salesdemos.github.io/api-specs/llms.txt",
+    "url": "https://f5-sales-demo.github.io/api-specs/llms.txt",
     "description": "OpenAPI spec validation and reconciliation for F5 Distributed Cloud",
     "category": "api-specifications"
   },
   {
     "label": "API Specs Enriched",
-    "url": "https://f5xc-salesdemos.github.io/api-specs-enriched/llms.txt",
+    "url": "https://f5-sales-demo.github.io/api-specs-enriched/llms.txt",
     "description": "Enriched OpenAPI specifications for F5 Distributed Cloud",
     "category": "api-specifications"
   },
   {
     "label": "Client-Side Defense",
-    "url": "https://f5xc-salesdemos.github.io/csd/llms.txt",
+    "url": "https://f5-sales-demo.github.io/csd/llms.txt",
     "description": "F5 XC client-side defense",
     "category": "product-features"
   },
   {
     "label": "Docs Icons",
-    "url": "https://f5xc-salesdemos.github.io/docs-icons/llms.txt",
+    "url": "https://f5-sales-demo.github.io/docs-icons/llms.txt",
     "description": "NPM icon packages and plugins for the F5 XC documentation build system",
     "category": "build-platform"
   },
   {
     "label": "Terraform Provider",
-    "url": "https://f5xc-salesdemos.github.io/terraform-provider-f5xc/llms.txt",
+    "url": "https://f5-sales-demo.github.io/terraform-provider-f5xc/llms.txt",
     "description": "Terraform provider for F5 Distributed Cloud",
     "category": "developer-tools"
   },
   {
     "label": "Dev Container",
-    "url": "https://f5xc-salesdemos.github.io/devcontainer/llms.txt",
+    "url": "https://f5-sales-demo.github.io/devcontainer/llms.txt",
     "description": "Isolated development environment with AI coding tools",
     "category": "build-platform"
   },
   {
     "label": "Marketplace",
-    "url": "https://f5xc-salesdemos.github.io/marketplace/llms.txt",
+    "url": "https://f5-sales-demo.github.io/marketplace/llms.txt",
     "description": "AI-powered marketplace for F5 Distributed Cloud solutions",
     "category": "build-platform"
   },
   {
     "label": "xcsh",
-    "url": "https://f5xc-salesdemos.github.io/xcsh/llms.txt",
+    "url": "https://f5-sales-demo.github.io/xcsh/llms.txt",
     "description": "AI-powered development environment and CLI tool",
     "category": "developer-tools"
   },
   {
     "label": "VS Code Extension",
-    "url": "https://f5xc-salesdemos.github.io/vscode-f5xc-tools/llms.txt",
+    "url": "https://f5-sales-demo.github.io/vscode-f5xc-tools/llms.txt",
     "description": "VS Code extension for managing F5 Distributed Cloud resources",
     "category": "developer-tools"
   },
   {
     "label": "xcsh Chrome Extension",
-    "url": "https://f5xc-salesdemos.github.io/xcsh-chrome-extension/llms.txt",
+    "url": "https://f5-sales-demo.github.io/xcsh-chrome-extension/llms.txt",
     "description": "Chrome extension companion for the xcsh AI-powered F5 Distributed Cloud CLI",
     "category": "developer-tools"
   },
   {
     "label": "CDN Simulator",
-    "url": "https://f5xc-salesdemos.github.io/cdn-simulator/llms.txt",
+    "url": "https://f5-sales-demo.github.io/cdn-simulator/llms.txt",
     "description": "NGINX-based CDN edge node simulator for multi-vendor lab environments",
     "category": "lab-infrastructure"
   },
   {
     "label": "Origin Server",
-    "url": "https://f5xc-salesdemos.github.io/origin-server/llms.txt",
+    "url": "https://f5-sales-demo.github.io/origin-server/llms.txt",
     "description": "Ubuntu 24.04 origin server with vulnerable web applications for F5 XC demo environments",
     "category": "lab-infrastructure"
   },
   {
     "label": "Traffic Generator",
-    "url": "https://f5xc-salesdemos.github.io/traffic-generator/llms.txt",
+    "url": "https://f5-sales-demo.github.io/traffic-generator/llms.txt",
     "description": "Azure Ubuntu 24.04 VM with 50+ security tools and attack suites for F5 XC demo traffic generation",
     "category": "lab-infrastructure"
   },
   {
     "label": "Demo Resources",
-    "url": "https://f5xc-salesdemos.github.io/demo-resources/llms.txt",
+    "url": "https://f5-sales-demo.github.io/demo-resources/llms.txt",
     "description": "Catalog of pre-configured Azure VM components for F5 XC demo environments",
     "category": "lab-infrastructure"
   },
   {
     "label": "Console Catalog",
-    "url": "https://f5xc-salesdemos.github.io/console/llms.txt",
+    "url": "https://f5-sales-demo.github.io/console/llms.txt",
     "description": "Schema-driven inventory of the F5 XC administration console UI — routes, resources, workflows, and browser automation manifests",
     "category": "developer-tools"
   }

--- a/docs/pt-br/index.mdx
+++ b/docs/pt-br/index.mdx
@@ -19,7 +19,7 @@ i18n:
 ---
 
 import { CardGrid } from '@astrojs/starlight/components';
-import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
+import LinkCard from '@f5-sales-demo/docs-theme/components/LinkCard.astro';
 
 ## Soluções de Segurança
 
@@ -28,43 +28,43 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     icon="f5xc:web-app-and-api-protection"
     title="WAF"
     description="Configuração e políticas de firewall para aplicações web."
-    href="https://f5xc-salesdemos.github.io/waf/"
+    href="https://f5-sales-demo.github.io/waf/"
   />
   <LinkCard
     icon="f5xc:web-app-and-api-protection"
     title="API"
     description="Descoberta, proteção e políticas de segurança de API."
-    href="https://f5xc-salesdemos.github.io/api-protection/"
+    href="https://f5-sales-demo.github.io/api-protection/"
   />
   <LinkCard
     icon="f5xc:bot-defense"
     title="Bot Avançado"
     description="Defesa avançada contra bots com análise comportamental."
-    href="https://f5xc-salesdemos.github.io/bot-advanced/"
+    href="https://f5-sales-demo.github.io/bot-advanced/"
   />
   <LinkCard
     icon="f5xc:bot-defense"
     title="Bot Padrão"
     description="Defesa padrão contra bots com detecção baseada em assinaturas."
-    href="https://f5xc-salesdemos.github.io/bot-standard/"
+    href="https://f5-sales-demo.github.io/bot-standard/"
   />
   <LinkCard
     icon="f5xc:client-side-defense"
     title="CSD"
     description="Defesa no lado do cliente para ameaças baseadas em navegador."
-    href="https://f5xc-salesdemos.github.io/csd/"
+    href="https://f5-sales-demo.github.io/csd/"
   />
   <LinkCard
     icon="f5xc:ddos-and-transit-services"
     title="DDoS"
     description="Proteção contra negação de serviço distribuída."
-    href="https://f5xc-salesdemos.github.io/ddos/"
+    href="https://f5-sales-demo.github.io/ddos/"
   />
   <LinkCard
     icon="f5xc:web-app-scanning"
     title="WAS"
     description="Varredura de aplicações web e avaliação de vulnerabilidades."
-    href="https://f5xc-salesdemos.github.io/was/"
+    href="https://f5-sales-demo.github.io/was/"
   />
 </CardGrid>
 
@@ -75,25 +75,25 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     icon="f5xc:multi-cloud-network-connect"
     title="MCN"
     description="Redes multicloud e conectividade de sites."
-    href="https://f5xc-salesdemos.github.io/mcn/"
+    href="https://f5-sales-demo.github.io/mcn/"
   />
   <LinkCard
     icon="f5xc:content-delivery-network"
     title="CDN"
     description="Rede de distribuição de conteúdo e cache de borda."
-    href="https://f5xc-salesdemos.github.io/cdn/"
+    href="https://f5-sales-demo.github.io/cdn/"
   />
   <LinkCard
     icon="f5xc:dns-management"
     title="DNS"
     description="Gerenciamento de DNS, zonas e balanceamento de carga."
-    href="https://f5xc-salesdemos.github.io/dns/"
+    href="https://f5-sales-demo.github.io/dns/"
   />
   <LinkCard
     icon="f5xc:nginx-one"
     title="NGINX"
     description="Integração e gerenciamento de configuração do NGINX."
-    href="https://f5xc-salesdemos.github.io/nginx/"
+    href="https://f5-sales-demo.github.io/nginx/"
   />
 </CardGrid>
 
@@ -104,25 +104,25 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     icon="f5xc:distributed-apps"
     title="Servidor de Origem"
     description="VM Ubuntu 24.04 com 9 aplicações web vulneráveis para testes de WAF, API e defesa contra bots."
-    href="https://f5xc-salesdemos.github.io/origin-server/"
+    href="https://f5-sales-demo.github.io/origin-server/"
   />
   <LinkCard
     icon="f5xc:application-traffic-insight"
     title="Gerador de Tráfego"
     description="VM Azure com mais de 50 ferramentas de segurança e 7 suítes de ataque para geração de tráfego de demonstração."
-    href="https://f5xc-salesdemos.github.io/traffic-generator/"
+    href="https://f5-sales-demo.github.io/traffic-generator/"
   />
   <LinkCard
     icon="f5xc:content-delivery-network"
     title="Simulador de CDN"
     description="Simulador de nó de borda CDN baseado em NGINX com mais de 67 cabeçalhos específicos por fornecedor."
-    href="https://f5xc-salesdemos.github.io/cdn-simulator/"
+    href="https://f5-sales-demo.github.io/cdn-simulator/"
   />
   <LinkCard
     icon="f5xc:platform"
     title="Ver Todos os Componentes"
     description="Navegue pelo catálogo completo de recursos de demonstração."
-    href="https://f5xc-salesdemos.github.io/demo-resources/"
+    href="https://f5-sales-demo.github.io/demo-resources/"
   />
 </CardGrid>
 
@@ -133,13 +133,13 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     icon="f5xc:observability"
     title="Observabilidade"
     description="Monitoramento, métricas e insights de aplicações."
-    href="https://f5xc-salesdemos.github.io/observability/"
+    href="https://f5-sales-demo.github.io/observability/"
   />
   <LinkCard
     icon="f5xc:administration"
     title="Administração"
     description="Gerenciamento de tenant, RBAC e configurações da plataforma."
-    href="https://f5xc-salesdemos.github.io/administration/"
+    href="https://f5-sales-demo.github.io/administration/"
   />
 </CardGrid>
 
@@ -150,19 +150,19 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     icon="hashicorp-flight:terraform-color"
     title="Provedor Terraform"
     description="Provedor Terraform para F5 Distributed Cloud."
-    href="https://f5xc-salesdemos.github.io/terraform-provider-f5xc/"
+    href="https://f5-sales-demo.github.io/terraform-provider-f5xc/"
   />
   <LinkCard
     icon="f5xc:data-intelligence"
     title="Especificações de API"
     description="Validação e reconciliação de especificações OpenAPI para F5 Distributed Cloud."
-    href="https://f5xc-salesdemos.github.io/api-specs/"
+    href="https://f5-sales-demo.github.io/api-specs/"
   />
   <LinkCard
     icon="f5xc:data-intelligence"
     title="Especificações de API Enriquecidas"
     description="Especificações OpenAPI enriquecidas para F5 Distributed Cloud."
-    href="https://f5xc-salesdemos.github.io/api-specs-enriched/"
+    href="https://f5-sales-demo.github.io/api-specs-enriched/"
   />
 </CardGrid>
 
@@ -173,31 +173,31 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     icon="f5xc:doc"
     title="Builder"
     description="Sistema de compilação de documentação Astro + Starlight em contêiner."
-    href="https://f5xc-salesdemos.github.io/docs-builder/"
+    href="https://f5-sales-demo.github.io/docs-builder/"
   />
   <LinkCard
     icon="f5xc:shared-configuration"
     title="Tema"
     description="Identidade visual e estilos compartilhados para sites de documentação."
-    href="https://f5xc-salesdemos.github.io/docs-theme/"
+    href="https://f5-sales-demo.github.io/docs-theme/"
   />
   <LinkCard
     icon="f5xc:distributed-apps"
     title="Ícones"
     description="Pacotes de ícones NPM e plugins para o sistema de compilação de documentação."
-    href="https://f5xc-salesdemos.github.io/docs-icons/"
+    href="https://f5-sales-demo.github.io/docs-icons/"
   />
   <LinkCard
     icon="f5xc:shared-configuration"
     title="Controle"
     description="Fluxos de trabalho de CI, modelos de governança e aplicação de configurações de repositório."
-    href="https://f5xc-salesdemos.github.io/docs-control/"
+    href="https://f5-sales-demo.github.io/docs-control/"
   />
   <LinkCard
     icon="hashicorp-flight:docker-color"
     title="Dev Container"
     description="Ambiente de desenvolvimento isolado com ferramentas de codificação com IA."
-    href="https://f5xc-salesdemos.github.io/devcontainer/"
+    href="https://f5-sales-demo.github.io/devcontainer/"
   />
 </CardGrid>
 
@@ -208,19 +208,19 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     icon="f5xc:distributed-apps"
     title="Extensão VS Code"
     description="Gerencie recursos F5 XC a partir do VS Code com IntelliSense e assistente de chat xcsh."
-    href="https://f5xc-salesdemos.github.io/vscode-f5xc-tools/"
+    href="https://f5-sales-demo.github.io/vscode-f5xc-tools/"
   />
   <LinkCard
     icon="f5xc:ai_assistant_logo"
     title="xcsh CLI"
     description="Shell com inteligência artificial para operações do F5 Distributed Cloud."
-    href="https://f5xc-salesdemos.github.io/xcsh/"
+    href="https://f5-sales-demo.github.io/xcsh/"
   />
   <LinkCard
     icon="f5xc:ai_assistant_logo"
     title="Extensão do Chrome xcsh"
     description="Controle o console do F5 Distributed Cloud com o assistente de IA xcsh."
-    href="https://f5xc-salesdemos.github.io/xcsh-chrome-extension/"
+    href="https://f5-sales-demo.github.io/xcsh-chrome-extension/"
   />
 </CardGrid>
 
@@ -231,12 +231,12 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     icon="f5xc:ai_assistant_logo"
     title="Marketplace"
     description="Marketplace com inteligência artificial para soluções F5 Distributed Cloud."
-    href="https://f5xc-salesdemos.github.io/marketplace/"
+    href="https://f5-sales-demo.github.io/marketplace/"
   />
   <LinkCard
     icon="f5xc:ai_assistant_logo"
     title="Catálogo do Console"
     description="Catálogo baseado em esquemas de rotas, recursos e fluxos de trabalho de automação do navegador do console F5 XC para gerenciamento de interface de usuário orientado por IA."
-    href="https://f5xc-salesdemos.github.io/console/"
+    href="https://f5-sales-demo.github.io/console/"
   />
 </CardGrid>

--- a/docs/th/index.mdx
+++ b/docs/th/index.mdx
@@ -15,7 +15,7 @@ i18n:
 ---
 
 import { CardGrid } from '@astrojs/starlight/components';
-import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
+import LinkCard from '@f5-sales-demo/docs-theme/components/LinkCard.astro';
 
 ## โซลูชันความปลอดภัย
 
@@ -24,43 +24,43 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     icon="f5xc:web-app-and-api-protection"
     title="WAF"
     description="การกำหนดค่าและนโยบายไฟร์วอลล์แอปพลิเคชันเว็บ"
-    href="https://f5xc-salesdemos.github.io/waf/"
+    href="https://f5-sales-demo.github.io/waf/"
   />
   <LinkCard
     icon="f5xc:web-app-and-api-protection"
     title="API"
     description="การค้นพบ API การป้องกัน และนโยบายความปลอดภัย"
-    href="https://f5xc-salesdemos.github.io/api-protection/"
+    href="https://f5-sales-demo.github.io/api-protection/"
   />
   <LinkCard
     icon="f5xc:bot-defense"
     title="Bot Advanced"
     description="การป้องกัน Bot ขั้นสูงด้วยการวิเคราะห์พฤติกรรม"
-    href="https://f5xc-salesdemos.github.io/bot-advanced/"
+    href="https://f5-sales-demo.github.io/bot-advanced/"
   />
   <LinkCard
     icon="f5xc:bot-defense"
     title="Bot Standard"
     description="การป้องกัน Bot มาตรฐานด้วยการตรวจจับแบบ Signature"
-    href="https://f5xc-salesdemos.github.io/bot-standard/"
+    href="https://f5-sales-demo.github.io/bot-standard/"
   />
   <LinkCard
     icon="f5xc:client-side-defense"
     title="CSD"
     description="การป้องกันฝั่งไคลเอนต์สำหรับภัยคุกคามที่มาจากเบราว์เซอร์"
-    href="https://f5xc-salesdemos.github.io/csd/"
+    href="https://f5-sales-demo.github.io/csd/"
   />
   <LinkCard
     icon="f5xc:ddos-and-transit-services"
     title="DDoS"
     description="การป้องกันการโจมตีแบบ Distributed Denial-of-Service"
-    href="https://f5xc-salesdemos.github.io/ddos/"
+    href="https://f5-sales-demo.github.io/ddos/"
   />
   <LinkCard
     icon="f5xc:web-app-scanning"
     title="WAS"
     description="การสแกนแอปพลิเคชันเว็บและการประเมินช่องโหว่"
-    href="https://f5xc-salesdemos.github.io/was/"
+    href="https://f5-sales-demo.github.io/was/"
   />
 </CardGrid>
 
@@ -71,25 +71,25 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     icon="f5xc:multi-cloud-network-connect"
     title="MCN"
     description="เครือข่ายมัลติคลาวด์และการเชื่อมต่อไซต์"
-    href="https://f5xc-salesdemos.github.io/mcn/"
+    href="https://f5-sales-demo.github.io/mcn/"
   />
   <LinkCard
     icon="f5xc:content-delivery-network"
     title="CDN"
     description="เครือข่ายการส่งมอบเนื้อหาและการแคชที่ Edge"
-    href="https://f5xc-salesdemos.github.io/cdn/"
+    href="https://f5-sales-demo.github.io/cdn/"
   />
   <LinkCard
     icon="f5xc:dns-management"
     title="DNS"
     description="การจัดการ DNS โซน และการกระจายโหลด"
-    href="https://f5xc-salesdemos.github.io/dns/"
+    href="https://f5-sales-demo.github.io/dns/"
   />
   <LinkCard
     icon="f5xc:nginx-one"
     title="NGINX"
     description="การรวม NGINX และการจัดการการกำหนดค่า"
-    href="https://f5xc-salesdemos.github.io/nginx/"
+    href="https://f5-sales-demo.github.io/nginx/"
   />
 </CardGrid>
 
@@ -100,25 +100,25 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     icon="f5xc:distributed-apps"
     title="เซิร์ฟเวอร์ต้นทาง"
     description="VM Ubuntu 24.04 พร้อมแอปพลิเคชันเว็บที่มีช่องโหว่ 9 รายการสำหรับทดสอบ WAF API และการป้องกัน Bot"
-    href="https://f5xc-salesdemos.github.io/origin-server/"
+    href="https://f5-sales-demo.github.io/origin-server/"
   />
   <LinkCard
     icon="f5xc:application-traffic-insight"
     title="ตัวสร้างทราฟฟิก"
     description="Azure VM พร้อมเครื่องมือความปลอดภัยกว่า 50 รายการและชุดการโจมตี 7 ชุดสำหรับการสร้างทราฟฟิกสาธิต"
-    href="https://f5xc-salesdemos.github.io/traffic-generator/"
+    href="https://f5-sales-demo.github.io/traffic-generator/"
   />
   <LinkCard
     icon="f5xc:content-delivery-network"
     title="ตัวจำลอง CDN"
     description="ตัวจำลอง CDN Edge Node ที่ใช้ NGINX พร้อม Header เฉพาะผู้ขายกว่า 67 รายการ"
-    href="https://f5xc-salesdemos.github.io/cdn-simulator/"
+    href="https://f5-sales-demo.github.io/cdn-simulator/"
   />
   <LinkCard
     icon="f5xc:platform"
     title="ดูส่วนประกอบทั้งหมด"
     description="เรียกดูแคตาล็อกทรัพยากรสาธิตทั้งหมด"
-    href="https://f5xc-salesdemos.github.io/demo-resources/"
+    href="https://f5-sales-demo.github.io/demo-resources/"
   />
 </CardGrid>
 
@@ -129,13 +129,13 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     icon="f5xc:observability"
     title="การสังเกตการณ์"
     description="การตรวจสอบ เมตริก และข้อมูลเชิงลึกของแอปพลิเคชัน"
-    href="https://f5xc-salesdemos.github.io/observability/"
+    href="https://f5-sales-demo.github.io/observability/"
   />
   <LinkCard
     icon="f5xc:administration"
     title="การบริหาร"
     description="การจัดการ Tenant RBAC และการตั้งค่าแพลตฟอร์ม"
-    href="https://f5xc-salesdemos.github.io/administration/"
+    href="https://f5-sales-demo.github.io/administration/"
   />
 </CardGrid>
 
@@ -146,19 +146,19 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     icon="hashicorp-flight:terraform-color"
     title="Terraform Provider"
     description="Terraform Provider สำหรับ F5 Distributed Cloud"
-    href="https://f5xc-salesdemos.github.io/terraform-provider-f5xc/"
+    href="https://f5-sales-demo.github.io/terraform-provider-f5xc/"
   />
   <LinkCard
     icon="f5xc:data-intelligence"
     title="ข้อกำหนด API"
     description="การตรวจสอบความถูกต้องของ OpenAPI Spec และการประสานสำหรับ F5 Distributed Cloud"
-    href="https://f5xc-salesdemos.github.io/api-specs/"
+    href="https://f5-sales-demo.github.io/api-specs/"
   />
   <LinkCard
     icon="f5xc:data-intelligence"
     title="ข้อกำหนด API ที่เพิ่มประสิทธิภาพ"
     description="OpenAPI Specification ที่เพิ่มประสิทธิภาพสำหรับ F5 Distributed Cloud"
-    href="https://f5xc-salesdemos.github.io/api-specs-enriched/"
+    href="https://f5-sales-demo.github.io/api-specs-enriched/"
   />
 </CardGrid>
 
@@ -169,31 +169,31 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     icon="f5xc:doc"
     title="Builder"
     description="ระบบสร้างเอกสารแบบ Containerized ด้วย Astro + Starlight"
-    href="https://f5xc-salesdemos.github.io/docs-builder/"
+    href="https://f5-sales-demo.github.io/docs-builder/"
   />
   <LinkCard
     icon="f5xc:shared-configuration"
     title="Theme"
     description="การสร้างแบรนด์และสไตล์ที่ใช้ร่วมกันสำหรับเว็บไซต์เอกสาร"
-    href="https://f5xc-salesdemos.github.io/docs-theme/"
+    href="https://f5-sales-demo.github.io/docs-theme/"
   />
   <LinkCard
     icon="f5xc:distributed-apps"
     title="Icons"
     description="แพ็กเกจไอคอน NPM และปลั๊กอินสำหรับระบบสร้างเอกสาร"
-    href="https://f5xc-salesdemos.github.io/docs-icons/"
+    href="https://f5-sales-demo.github.io/docs-icons/"
   />
   <LinkCard
     icon="f5xc:shared-configuration"
     title="Control"
     description="เวิร์กโฟลว์ CI เทมเพลตการกำกับดูแล และการบังคับใช้การตั้งค่า Repository"
-    href="https://f5xc-salesdemos.github.io/docs-control/"
+    href="https://f5-sales-demo.github.io/docs-control/"
   />
   <LinkCard
     icon="hashicorp-flight:docker-color"
     title="คอนเทนเนอร์สำหรับพัฒนา"
     description="สภาพแวดล้อมการพัฒนาแบบแยกส่วนพร้อมเครื่องมือ AI สำหรับเขียนโค้ด"
-    href="https://f5xc-salesdemos.github.io/devcontainer/"
+    href="https://f5-sales-demo.github.io/devcontainer/"
   />
 </CardGrid>
 
@@ -204,19 +204,19 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     icon="f5xc:distributed-apps"
     title="VS Code ส่วนขยาย"
     description="จัดการทรัพยากร F5 XC จาก VS Code ด้วย IntelliSense และผู้ช่วยแชท xcsh"
-    href="https://f5xc-salesdemos.github.io/vscode-f5xc-tools/"
+    href="https://f5-sales-demo.github.io/vscode-f5xc-tools/"
   />
   <LinkCard
     icon="f5xc:ai_assistant_logo"
     title="xcsh CLI"
     description="Shell ที่ขับเคลื่อนด้วย AI สำหรับการดำเนินงาน F5 Distributed Cloud"
-    href="https://f5xc-salesdemos.github.io/xcsh/"
+    href="https://f5-sales-demo.github.io/xcsh/"
   />
   <LinkCard
     icon="f5xc:ai_assistant_logo"
     title="ส่วนขยาย Chrome ของ xcsh"
     description="ควบคุมคอนโซล F5 Distributed Cloud ด้วยผู้ช่วย AI ของ xcsh"
-    href="https://f5xc-salesdemos.github.io/xcsh-chrome-extension/"
+    href="https://f5-sales-demo.github.io/xcsh-chrome-extension/"
   />
 </CardGrid>
 
@@ -227,12 +227,12 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     icon="f5xc:ai_assistant_logo"
     title="ตลาดกลาง"
     description="ตลาดกลางที่ขับเคลื่อนด้วย AI สำหรับโซลูชัน F5 Distributed Cloud"
-    href="https://f5xc-salesdemos.github.io/marketplace/"
+    href="https://f5-sales-demo.github.io/marketplace/"
   />
   <LinkCard
     icon="f5xc:ai_assistant_logo"
     title="แคตตาล็อกคอนโซล"
     description="แคตตาล็อกที่ขับเคลื่อนด้วยสคีมาของเส้นทาง ทรัพยากร และเวิร์กโฟลว์การทำงานอัตโนมัติของเบราว์เซอร์ในคอนโซล F5 XC สำหรับการจัดการ UI ที่ขับเคลื่อนด้วย AI"
-    href="https://f5xc-salesdemos.github.io/console/"
+    href="https://f5-sales-demo.github.io/console/"
   />
 </CardGrid>

--- a/docs/zh-cn/index.mdx
+++ b/docs/zh-cn/index.mdx
@@ -15,7 +15,7 @@ i18n:
 ---
 
 import { CardGrid } from '@astrojs/starlight/components';
-import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
+import LinkCard from '@f5-sales-demo/docs-theme/components/LinkCard.astro';
 
 ## 安全解决方案
 
@@ -24,43 +24,43 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     icon="f5xc:web-app-and-api-protection"
     title="WAF"
     description="Web 应用防火墙配置与策略。"
-    href="https://f5xc-salesdemos.github.io/waf/"
+    href="https://f5-sales-demo.github.io/waf/"
   />
   <LinkCard
     icon="f5xc:web-app-and-api-protection"
     title="API"
     description="API 发现、防护及安全策略。"
-    href="https://f5xc-salesdemos.github.io/api-protection/"
+    href="https://f5-sales-demo.github.io/api-protection/"
   />
   <LinkCard
     icon="f5xc:bot-defense"
     title="Bot Advanced"
     description="基于行为分析的高级机器人防御。"
-    href="https://f5xc-salesdemos.github.io/bot-advanced/"
+    href="https://f5-sales-demo.github.io/bot-advanced/"
   />
   <LinkCard
     icon="f5xc:bot-defense"
     title="Bot Standard"
     description="基于特征检测的标准机器人防御。"
-    href="https://f5xc-salesdemos.github.io/bot-standard/"
+    href="https://f5-sales-demo.github.io/bot-standard/"
   />
   <LinkCard
     icon="f5xc:client-side-defense"
     title="CSD"
     description="针对浏览器端威胁的客户端防御。"
-    href="https://f5xc-salesdemos.github.io/csd/"
+    href="https://f5-sales-demo.github.io/csd/"
   />
   <LinkCard
     icon="f5xc:ddos-and-transit-services"
     title="DDoS"
     description="分布式拒绝服务攻击防护。"
-    href="https://f5xc-salesdemos.github.io/ddos/"
+    href="https://f5-sales-demo.github.io/ddos/"
   />
   <LinkCard
     icon="f5xc:web-app-scanning"
     title="WAS"
     description="Web 应用扫描与漏洞评估。"
-    href="https://f5xc-salesdemos.github.io/was/"
+    href="https://f5-sales-demo.github.io/was/"
   />
 </CardGrid>
 
@@ -71,25 +71,25 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     icon="f5xc:multi-cloud-network-connect"
     title="MCN"
     description="多云网络与站点互联。"
-    href="https://f5xc-salesdemos.github.io/mcn/"
+    href="https://f5-sales-demo.github.io/mcn/"
   />
   <LinkCard
     icon="f5xc:content-delivery-network"
     title="CDN"
     description="内容分发网络与边缘缓存。"
-    href="https://f5xc-salesdemos.github.io/cdn/"
+    href="https://f5-sales-demo.github.io/cdn/"
   />
   <LinkCard
     icon="f5xc:dns-management"
     title="DNS"
     description="DNS 管理、区域配置与负载均衡。"
-    href="https://f5xc-salesdemos.github.io/dns/"
+    href="https://f5-sales-demo.github.io/dns/"
   />
   <LinkCard
     icon="f5xc:nginx-one"
     title="NGINX"
     description="NGINX 集成与配置管理。"
-    href="https://f5xc-salesdemos.github.io/nginx/"
+    href="https://f5-sales-demo.github.io/nginx/"
   />
 </CardGrid>
 
@@ -100,25 +100,25 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     icon="f5xc:distributed-apps"
     title="源服务器"
     description="搭载 9 个存在漏洞的 Web 应用的 Ubuntu 24.04 虚拟机，用于 WAF、API 及机器人防御测试。"
-    href="https://f5xc-salesdemos.github.io/origin-server/"
+    href="https://f5-sales-demo.github.io/origin-server/"
   />
   <LinkCard
     icon="f5xc:application-traffic-insight"
     title="流量生成器"
     description="搭载 50 余种安全工具和 7 个攻击套件的 Azure 虚拟机，用于演示流量生成。"
-    href="https://f5xc-salesdemos.github.io/traffic-generator/"
+    href="https://f5-sales-demo.github.io/traffic-generator/"
   />
   <LinkCard
     icon="f5xc:content-delivery-network"
     title="CDN 模拟器"
     description="基于 NGINX 的 CDN 边缘节点模拟器，支持 67 种以上厂商专用请求头。"
-    href="https://f5xc-salesdemos.github.io/cdn-simulator/"
+    href="https://f5-sales-demo.github.io/cdn-simulator/"
   />
   <LinkCard
     icon="f5xc:platform"
     title="查看全部组件"
     description="浏览完整的演示资源目录。"
-    href="https://f5xc-salesdemos.github.io/demo-resources/"
+    href="https://f5-sales-demo.github.io/demo-resources/"
   />
 </CardGrid>
 
@@ -129,13 +129,13 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     icon="f5xc:observability"
     title="可观测性"
     description="监控、指标与应用洞察。"
-    href="https://f5xc-salesdemos.github.io/observability/"
+    href="https://f5-sales-demo.github.io/observability/"
   />
   <LinkCard
     icon="f5xc:administration"
     title="管理"
     description="租户管理、RBAC 及平台设置。"
-    href="https://f5xc-salesdemos.github.io/administration/"
+    href="https://f5-sales-demo.github.io/administration/"
   />
 </CardGrid>
 
@@ -146,19 +146,19 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     icon="hashicorp-flight:terraform-color"
     title="Terraform Provider"
     description="适用于 F5 分布式云的 Terraform Provider。"
-    href="https://f5xc-salesdemos.github.io/terraform-provider-f5xc/"
+    href="https://f5-sales-demo.github.io/terraform-provider-f5xc/"
   />
   <LinkCard
     icon="f5xc:data-intelligence"
     title="API 规范"
     description="适用于 F5 分布式云的 OpenAPI 规范验证与协调。"
-    href="https://f5xc-salesdemos.github.io/api-specs/"
+    href="https://f5-sales-demo.github.io/api-specs/"
   />
   <LinkCard
     icon="f5xc:data-intelligence"
     title="增强型 API 规范"
     description="适用于 F5 分布式云的增强型 OpenAPI 规范。"
-    href="https://f5xc-salesdemos.github.io/api-specs-enriched/"
+    href="https://f5-sales-demo.github.io/api-specs-enriched/"
   />
 </CardGrid>
 
@@ -169,31 +169,31 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     icon="f5xc:doc"
     title="构建器"
     description="基于容器化 Astro + Starlight 的文档构建系统。"
-    href="https://f5xc-salesdemos.github.io/docs-builder/"
+    href="https://f5-sales-demo.github.io/docs-builder/"
   />
   <LinkCard
     icon="f5xc:shared-configuration"
     title="主题"
     description="文档站点的共享品牌标识与样式。"
-    href="https://f5xc-salesdemos.github.io/docs-theme/"
+    href="https://f5-sales-demo.github.io/docs-theme/"
   />
   <LinkCard
     icon="f5xc:distributed-apps"
     title="图标"
     description="适用于文档构建系统的 NPM 图标包与插件。"
-    href="https://f5xc-salesdemos.github.io/docs-icons/"
+    href="https://f5-sales-demo.github.io/docs-icons/"
   />
   <LinkCard
     icon="f5xc:shared-configuration"
     title="管控"
     description="CI 工作流、治理模板及代码仓库设置强制执行。"
-    href="https://f5xc-salesdemos.github.io/docs-control/"
+    href="https://f5-sales-demo.github.io/docs-control/"
   />
   <LinkCard
     icon="hashicorp-flight:docker-color"
     title="开发容器"
     description="集成 AI 编码工具的隔离开发环境。"
-    href="https://f5xc-salesdemos.github.io/devcontainer/"
+    href="https://f5-sales-demo.github.io/devcontainer/"
   />
 </CardGrid>
 
@@ -204,19 +204,19 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     icon="f5xc:distributed-apps"
     title="VS Code 扩展"
     description="通过 IntelliSense 和 xcsh 聊天助手在 VS Code 中管理 F5 XC 资源。"
-    href="https://f5xc-salesdemos.github.io/vscode-f5xc-tools/"
+    href="https://f5-sales-demo.github.io/vscode-f5xc-tools/"
   />
   <LinkCard
     icon="f5xc:ai_assistant_logo"
     title="xcsh CLI"
     description="适用于 F5 分布式云运营的 AI 驱动命令行工具。"
-    href="https://f5xc-salesdemos.github.io/xcsh/"
+    href="https://f5-sales-demo.github.io/xcsh/"
   />
   <LinkCard
     icon="f5xc:ai_assistant_logo"
     title="xcsh Chrome 扩展"
     description="使用 xcsh AI 助手驱动 F5 Distributed Cloud 控制台。"
-    href="https://f5xc-salesdemos.github.io/xcsh-chrome-extension/"
+    href="https://f5-sales-demo.github.io/xcsh-chrome-extension/"
   />
 </CardGrid>
 
@@ -227,12 +227,12 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     icon="f5xc:ai_assistant_logo"
     title="应用市场"
     description="适用于 F5 分布式云解决方案的 AI 驱动应用市场。"
-    href="https://f5xc-salesdemos.github.io/marketplace/"
+    href="https://f5-sales-demo.github.io/marketplace/"
   />
   <LinkCard
     icon="f5xc:ai_assistant_logo"
     title="控制台目录"
     description="用于 AI 驱动 UI 管理的 F5 XC 控制台路由、资源和浏览器自动化工作流的模式驱动目录。"
-    href="https://f5xc-salesdemos.github.io/console/"
+    href="https://f5-sales-demo.github.io/console/"
   />
 </CardGrid>

--- a/docs/zh-tw/index.mdx
+++ b/docs/zh-tw/index.mdx
@@ -15,7 +15,7 @@ i18n:
 ---
 
 import { CardGrid } from '@astrojs/starlight/components';
-import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
+import LinkCard from '@f5-sales-demo/docs-theme/components/LinkCard.astro';
 
 ## 安全解決方案
 
@@ -24,43 +24,43 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     icon="f5xc:web-app-and-api-protection"
     title="WAF"
     description="Web 應用程式防火牆設定與原則。"
-    href="https://f5xc-salesdemos.github.io/waf/"
+    href="https://f5-sales-demo.github.io/waf/"
   />
   <LinkCard
     icon="f5xc:web-app-and-api-protection"
     title="API"
     description="API 探索、保護與安全原則。"
-    href="https://f5xc-salesdemos.github.io/api-protection/"
+    href="https://f5-sales-demo.github.io/api-protection/"
   />
   <LinkCard
     icon="f5xc:bot-defense"
     title="Bot 進階版"
     description="具備行為分析的進階機器人防禦。"
-    href="https://f5xc-salesdemos.github.io/bot-advanced/"
+    href="https://f5-sales-demo.github.io/bot-advanced/"
   />
   <LinkCard
     icon="f5xc:bot-defense"
     title="Bot 標準版"
     description="基於特徵碼偵測的標準機器人防禦。"
-    href="https://f5xc-salesdemos.github.io/bot-standard/"
+    href="https://f5-sales-demo.github.io/bot-standard/"
   />
   <LinkCard
     icon="f5xc:client-side-defense"
     title="CSD"
     description="針對瀏覽器型威脅的用戶端防禦。"
-    href="https://f5xc-salesdemos.github.io/csd/"
+    href="https://f5-sales-demo.github.io/csd/"
   />
   <LinkCard
     icon="f5xc:ddos-and-transit-services"
     title="DDoS"
     description="分散式阻斷服務攻擊防護。"
-    href="https://f5xc-salesdemos.github.io/ddos/"
+    href="https://f5-sales-demo.github.io/ddos/"
   />
   <LinkCard
     icon="f5xc:web-app-scanning"
     title="WAS"
     description="Web 應用程式掃描與弱點評估。"
-    href="https://f5xc-salesdemos.github.io/was/"
+    href="https://f5-sales-demo.github.io/was/"
   />
 </CardGrid>
 
@@ -71,25 +71,25 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     icon="f5xc:multi-cloud-network-connect"
     title="MCN"
     description="多雲網路與站點連線。"
-    href="https://f5xc-salesdemos.github.io/mcn/"
+    href="https://f5-sales-demo.github.io/mcn/"
   />
   <LinkCard
     icon="f5xc:content-delivery-network"
     title="CDN"
     description="內容傳遞網路與邊緣快取。"
-    href="https://f5xc-salesdemos.github.io/cdn/"
+    href="https://f5-sales-demo.github.io/cdn/"
   />
   <LinkCard
     icon="f5xc:dns-management"
     title="DNS"
     description="DNS 管理、區域設定與負載平衡。"
-    href="https://f5xc-salesdemos.github.io/dns/"
+    href="https://f5-sales-demo.github.io/dns/"
   />
   <LinkCard
     icon="f5xc:nginx-one"
     title="NGINX"
     description="NGINX 整合與設定管理。"
-    href="https://f5xc-salesdemos.github.io/nginx/"
+    href="https://f5-sales-demo.github.io/nginx/"
   />
 </CardGrid>
 
@@ -100,25 +100,25 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     icon="f5xc:distributed-apps"
     title="來源伺服器"
     description="搭載 9 個具漏洞 Web 應用程式的 Ubuntu 24.04 VM，用於 WAF、API 及機器人防禦測試。"
-    href="https://f5xc-salesdemos.github.io/origin-server/"
+    href="https://f5-sales-demo.github.io/origin-server/"
   />
   <LinkCard
     icon="f5xc:application-traffic-insight"
     title="流量產生器"
     description="搭載 50 餘種安全工具與 7 套攻擊套件的 Azure VM，用於示範流量產生。"
-    href="https://f5xc-salesdemos.github.io/traffic-generator/"
+    href="https://f5-sales-demo.github.io/traffic-generator/"
   />
   <LinkCard
     icon="f5xc:content-delivery-network"
     title="CDN 模擬器"
     description="基於 NGINX 的 CDN 邊緣節點模擬器，支援 67 種以上廠商專屬標頭。"
-    href="https://f5xc-salesdemos.github.io/cdn-simulator/"
+    href="https://f5-sales-demo.github.io/cdn-simulator/"
   />
   <LinkCard
     icon="f5xc:platform"
     title="檢視所有元件"
     description="瀏覽完整的示範資源目錄。"
-    href="https://f5xc-salesdemos.github.io/demo-resources/"
+    href="https://f5-sales-demo.github.io/demo-resources/"
   />
 </CardGrid>
 
@@ -129,13 +129,13 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     icon="f5xc:observability"
     title="可觀測性"
     description="監控、指標與應用程式洞察。"
-    href="https://f5xc-salesdemos.github.io/observability/"
+    href="https://f5-sales-demo.github.io/observability/"
   />
   <LinkCard
     icon="f5xc:administration"
     title="系統管理"
     description="租戶管理、RBAC 與平台設定。"
-    href="https://f5xc-salesdemos.github.io/administration/"
+    href="https://f5-sales-demo.github.io/administration/"
   />
 </CardGrid>
 
@@ -146,19 +146,19 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     icon="hashicorp-flight:terraform-color"
     title="Terraform 提供者"
     description="適用於 F5 Distributed Cloud 的 Terraform 提供者。"
-    href="https://f5xc-salesdemos.github.io/terraform-provider-f5xc/"
+    href="https://f5-sales-demo.github.io/terraform-provider-f5xc/"
   />
   <LinkCard
     icon="f5xc:data-intelligence"
     title="API 規格"
     description="適用於 F5 Distributed Cloud 的 OpenAPI 規格驗證與調和。"
-    href="https://f5xc-salesdemos.github.io/api-specs/"
+    href="https://f5-sales-demo.github.io/api-specs/"
   />
   <LinkCard
     icon="f5xc:data-intelligence"
     title="API 規格（增強版）"
     description="適用於 F5 Distributed Cloud 的增強版 OpenAPI 規格。"
-    href="https://f5xc-salesdemos.github.io/api-specs-enriched/"
+    href="https://f5-sales-demo.github.io/api-specs-enriched/"
   />
 </CardGrid>
 
@@ -169,31 +169,31 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     icon="f5xc:doc"
     title="建置工具"
     description="容器化的 Astro + Starlight 文件建置系統。"
-    href="https://f5xc-salesdemos.github.io/docs-builder/"
+    href="https://f5-sales-demo.github.io/docs-builder/"
   />
   <LinkCard
     icon="f5xc:shared-configuration"
     title="佈景主題"
     description="適用於文件網站的共用品牌與樣式。"
-    href="https://f5xc-salesdemos.github.io/docs-theme/"
+    href="https://f5-sales-demo.github.io/docs-theme/"
   />
   <LinkCard
     icon="f5xc:distributed-apps"
     title="圖示"
     description="適用於文件建置系統的 NPM 圖示套件與外掛程式。"
-    href="https://f5xc-salesdemos.github.io/docs-icons/"
+    href="https://f5-sales-demo.github.io/docs-icons/"
   />
   <LinkCard
     icon="f5xc:shared-configuration"
     title="控制中心"
     description="CI 工作流程、治理範本與儲存庫設定強制執行。"
-    href="https://f5xc-salesdemos.github.io/docs-control/"
+    href="https://f5-sales-demo.github.io/docs-control/"
   />
   <LinkCard
     icon="hashicorp-flight:docker-color"
     title="開發容器"
     description="整合 AI 程式開發工具的隔離式開發環境。"
-    href="https://f5xc-salesdemos.github.io/devcontainer/"
+    href="https://f5-sales-demo.github.io/devcontainer/"
   />
 </CardGrid>
 
@@ -204,19 +204,19 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     icon="f5xc:distributed-apps"
     title="VS Code 擴充功能"
     description="透過 IntelliSense 與 xcsh 聊天助理，從 VS Code 管理 F5 XC 資源。"
-    href="https://f5xc-salesdemos.github.io/vscode-f5xc-tools/"
+    href="https://f5-sales-demo.github.io/vscode-f5xc-tools/"
   />
   <LinkCard
     icon="f5xc:ai_assistant_logo"
     title="xcsh CLI"
     description="適用於 F5 Distributed Cloud 運維的 AI 驅動 Shell。"
-    href="https://f5xc-salesdemos.github.io/xcsh/"
+    href="https://f5-sales-demo.github.io/xcsh/"
   />
   <LinkCard
     icon="f5xc:ai_assistant_logo"
     title="xcsh Chrome 擴充功能"
     description="使用 xcsh AI 助理驅動 F5 Distributed Cloud 主控台。"
-    href="https://f5xc-salesdemos.github.io/xcsh-chrome-extension/"
+    href="https://f5-sales-demo.github.io/xcsh-chrome-extension/"
   />
 </CardGrid>
 
@@ -227,12 +227,12 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
     icon="f5xc:ai_assistant_logo"
     title="應用市集"
     description="適用於 F5 Distributed Cloud 解決方案的 AI 驅動應用市集。"
-    href="https://f5xc-salesdemos.github.io/marketplace/"
+    href="https://f5-sales-demo.github.io/marketplace/"
   />
   <LinkCard
     icon="f5xc:ai_assistant_logo"
     title="控制台目錄"
     description="用於 AI 驅動 UI 管理的 F5 XC 控制台路由、資源和瀏覽器自動化工作流程的模式驅動目錄。"
-    href="https://f5xc-salesdemos.github.io/console/"
+    href="https://f5-sales-demo.github.io/console/"
   />
 </CardGrid>

--- a/scripts/locale-lint.sh
+++ b/scripts/locale-lint.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Detects hardcoded locale lists that should import from @f5xc-salesdemos/i18n-core.
+# Detects hardcoded locale lists that should import from @f5-sales-demo/i18n-core.
 # Run from any repo root: bash scripts/locale-lint.sh
 # Exit 0 = clean, Exit 1 = violations found.
 set -euo pipefail
@@ -30,7 +30,7 @@ check_pattern() {
     -E "$pattern" . 2>/dev/null |
     grep -vE "($EXCLUDE_DIRS)" |
     grep -vE "($EXCLUDE_FILES)" |
-    grep -vE "from\s+['\"]@f5xc-salesdemos/i18n-core" |
+    grep -vE "from\s+['\"]@f5-sales-demo/i18n-core" |
     grep -vE "i18n-core/(src|dist)/" ||
     true)
 
@@ -53,7 +53,7 @@ done
 echo ""
 if [ "$VIOLATIONS" -gt 0 ]; then
   echo "FAIL: Found $VIOLATIONS pattern(s) with hardcoded locale data."
-  echo "These should import from @f5xc-salesdemos/i18n-core instead."
+  echo "These should import from @f5-sales-demo/i18n-core instead."
   exit 1
 else
   echo "PASS: No hardcoded locale lists detected."


### PR DESCRIPTION
Closes #628

Updated 24 file(s) for org rename.

🤖 Generated with [Claude Code](https://claude.com/claude-code)