### PR TITLE
fix: restamp stale translation sourceHash (unblocks Translation freshness)

### DIFF
--- a/docs/ar/index.mdx
+++ b/docs/ar/index.mdx
@@ -10,7 +10,7 @@ hero:
       <img src="/docs/images/hero-platform.svg" alt="F5 Distributed Cloud
       platform" />
 i18n:
-  sourceHash: 72679f3e802e
+  sourceHash: 29a0827d18fb
   translator: machine
 ---
 

--- a/docs/de/index.mdx
+++ b/docs/de/index.mdx
@@ -10,7 +10,7 @@ hero:
       <img src="/docs/images/hero-platform.svg" alt="F5 Distributed Cloud
       platform" />
 i18n:
-  sourceHash: 72679f3e802e
+  sourceHash: 29a0827d18fb
   translator: machine
 ---
 

--- a/docs/es/index.mdx
+++ b/docs/es/index.mdx
@@ -14,7 +14,7 @@ hero:
       <img src="/docs/images/hero-platform.svg" alt="F5 Distributed Cloud
       platform" />
 i18n:
-  sourceHash: 72679f3e802e
+  sourceHash: 29a0827d18fb
   translator: machine
 ---
 

--- a/docs/fr/index.mdx
+++ b/docs/fr/index.mdx
@@ -14,7 +14,7 @@ hero:
       <img src="/docs/images/hero-platform.svg" alt="F5 Distributed Cloud
       platform" />
 i18n:
-  sourceHash: 72679f3e802e
+  sourceHash: 29a0827d18fb
   translator: machine
 ---
 

--- a/docs/hi/index.mdx
+++ b/docs/hi/index.mdx
@@ -10,7 +10,7 @@ hero:
       <img src="/docs/images/hero-platform.svg" alt="F5 Distributed Cloud
       platform" />
 i18n:
-  sourceHash: 72679f3e802e
+  sourceHash: 29a0827d18fb
   translator: machine
 ---
 

--- a/docs/it/index.mdx
+++ b/docs/it/index.mdx
@@ -10,7 +10,7 @@ hero:
       <img src="/docs/images/hero-platform.svg" alt="F5 Distributed Cloud
       platform" />
 i18n:
-  sourceHash: 72679f3e802e
+  sourceHash: 29a0827d18fb
   translator: machine
 ---
 

--- a/docs/ja/index.mdx
+++ b/docs/ja/index.mdx
@@ -10,7 +10,7 @@ hero:
       <img src="/docs/images/hero-platform.svg" alt="F5 Distributed Cloud
       platform" />
 i18n:
-  sourceHash: 72679f3e802e
+  sourceHash: 29a0827d18fb
   translator: machine
 ---
 

--- a/docs/ko/index.mdx
+++ b/docs/ko/index.mdx
@@ -10,7 +10,7 @@ hero:
       <img src="/docs/images/hero-platform.svg" alt="F5 Distributed Cloud
       platform" />
 i18n:
-  sourceHash: 72679f3e802e
+  sourceHash: 29a0827d18fb
   translator: machine
 ---
 

--- a/docs/pt-br/index.mdx
+++ b/docs/pt-br/index.mdx
@@ -14,7 +14,7 @@ hero:
       <img src="/docs/images/hero-platform.svg" alt="F5 Distributed Cloud
       platform" />
 i18n:
-  sourceHash: 72679f3e802e
+  sourceHash: 29a0827d18fb
   translator: machine
 ---
 

--- a/docs/th/index.mdx
+++ b/docs/th/index.mdx
@@ -10,7 +10,7 @@ hero:
       <img src="/docs/images/hero-platform.svg" alt="F5 Distributed Cloud
       platform" />
 i18n:
-  sourceHash: 72679f3e802e
+  sourceHash: 29a0827d18fb
   translator: machine
 ---
 

--- a/docs/zh-cn/index.mdx
+++ b/docs/zh-cn/index.mdx
@@ -10,7 +10,7 @@ hero:
       <img src="/docs/images/hero-platform.svg" alt="F5 Distributed Cloud
       platform" />
 i18n:
-  sourceHash: 72679f3e802e
+  sourceHash: 29a0827d18fb
   translator: machine
 ---
 

--- a/docs/zh-tw/index.mdx
+++ b/docs/zh-tw/index.mdx
@@ -10,7 +10,7 @@ hero:
       <img src="/docs/images/hero-platform.svg" alt="F5 Distributed Cloud
       platform" />
 i18n:
-  sourceHash: 72679f3e802e
+  sourceHash: 29a0827d18fb
   translator: machine
 ---
 


### PR DESCRIPTION
Restamps `i18n.sourceHash` in the 12 machine-translated locale `index.mdx` files to the current `sha256(en)[:12]`.

**Root cause:** org-rename sweep #629 updated en+locale content but never restamped the hash, so `audit / Translation freshness` fails though the translations are content-current (verified: only en delta since the stored hash is the org rename, already applied in locales).

**Change:** one `sourceHash` line per file — no prose edits. Local audit port confirms all translations fresh.

Unblocks the governance sync PR #657.

Closes #658