### PR TITLE
fix: update landing links to renamed xcsh repos (#680)

### DIFF
--- a/docs/ar/index.mdx
+++ b/docs/ar/index.mdx
@@ -10,7 +10,7 @@ hero:
       <img src="/docs/images/hero-platform.svg" alt="F5 Distributed Cloud
       platform" />
 i18n:
-  sourceHash: 29a0827d18fb
+  sourceHash: d80f962a2933
   translator: machine
 ---
 

--- a/docs/ar/index.mdx
+++ b/docs/ar/index.mdx
@@ -146,7 +146,7 @@ import LinkCard from '@f5-sales-demo/docs-theme/components/LinkCard.astro';
     icon="hashicorp-flight:terraform-color"
     title="موفر Terraform"
     description="موفر Terraform لـ F5 Distributed Cloud."
-    href="https://f5-sales-demo.github.io/terraform-provider-f5xc/"
+    href="https://f5-sales-demo.github.io/terraform-provider-xcsh/"
   />
   <LinkCard
     icon="f5xc:data-intelligence"
@@ -204,7 +204,7 @@ import LinkCard from '@f5-sales-demo/docs-theme/components/LinkCard.astro';
     icon="f5xc:distributed-apps"
     title="إضافة VS Code"
     description="إدارة موارد F5 XC من VS Code مع IntelliSense ومساعد الدردشة xcsh."
-    href="https://f5-sales-demo.github.io/vscode-f5xc-tools/"
+    href="https://f5-sales-demo.github.io/vscode-xcsh/"
   />
   <LinkCard
     icon="f5xc:ai_assistant_logo"

--- a/docs/de/index.mdx
+++ b/docs/de/index.mdx
@@ -10,7 +10,7 @@ hero:
       <img src="/docs/images/hero-platform.svg" alt="F5 Distributed Cloud
       platform" />
 i18n:
-  sourceHash: 29a0827d18fb
+  sourceHash: d80f962a2933
   translator: machine
 ---
 

--- a/docs/de/index.mdx
+++ b/docs/de/index.mdx
@@ -146,7 +146,7 @@ import LinkCard from '@f5-sales-demo/docs-theme/components/LinkCard.astro';
     icon="hashicorp-flight:terraform-color"
     title="Terraform-Provider"
     description="Terraform-Provider für F5 Distributed Cloud."
-    href="https://f5-sales-demo.github.io/terraform-provider-f5xc/"
+    href="https://f5-sales-demo.github.io/terraform-provider-xcsh/"
   />
   <LinkCard
     icon="f5xc:data-intelligence"
@@ -204,7 +204,7 @@ import LinkCard from '@f5-sales-demo/docs-theme/components/LinkCard.astro';
     icon="f5xc:distributed-apps"
     title="VS Code Erweiterung"
     description="F5 XC-Ressourcen aus VS Code verwalten mit IntelliSense und xcsh-Chat-Assistent."
-    href="https://f5-sales-demo.github.io/vscode-f5xc-tools/"
+    href="https://f5-sales-demo.github.io/vscode-xcsh/"
   />
   <LinkCard
     icon="f5xc:ai_assistant_logo"

--- a/docs/en/index.mdx
+++ b/docs/en/index.mdx
@@ -141,7 +141,7 @@ import LinkCard from '@f5-sales-demo/docs-theme/components/LinkCard.astro';
     icon="hashicorp-flight:terraform-color"
     title="Terraform Provider"
     description="Terraform provider for F5 Distributed Cloud."
-    href="https://f5-sales-demo.github.io/terraform-provider-f5xc/"
+    href="https://f5-sales-demo.github.io/terraform-provider-xcsh/"
   />
   <LinkCard
     icon="f5xc:data-intelligence"
@@ -199,7 +199,7 @@ import LinkCard from '@f5-sales-demo/docs-theme/components/LinkCard.astro';
     icon="f5xc:distributed-apps"
     title="VS Code Extension"
     description="Manage F5 XC resources from VS Code with IntelliSense and xcsh chat assistant."
-    href="https://f5-sales-demo.github.io/vscode-f5xc-tools/"
+    href="https://f5-sales-demo.github.io/vscode-xcsh/"
   />
   <LinkCard
     icon="f5xc:ai_assistant_logo"

--- a/docs/es/index.mdx
+++ b/docs/es/index.mdx
@@ -150,7 +150,7 @@ import LinkCard from '@f5-sales-demo/docs-theme/components/LinkCard.astro';
     icon="hashicorp-flight:terraform-color"
     title="Proveedor de Terraform"
     description="Proveedor de Terraform para F5 Distributed Cloud."
-    href="https://f5-sales-demo.github.io/terraform-provider-f5xc/"
+    href="https://f5-sales-demo.github.io/terraform-provider-xcsh/"
   />
   <LinkCard
     icon="f5xc:data-intelligence"
@@ -208,7 +208,7 @@ import LinkCard from '@f5-sales-demo/docs-theme/components/LinkCard.astro';
     icon="f5xc:distributed-apps"
     title="VS Code Extensión"
     description="Gestione recursos de F5 XC desde VS Code con IntelliSense y el asistente de chat xcsh."
-    href="https://f5-sales-demo.github.io/vscode-f5xc-tools/"
+    href="https://f5-sales-demo.github.io/vscode-xcsh/"
   />
   <LinkCard
     icon="f5xc:ai_assistant_logo"

--- a/docs/es/index.mdx
+++ b/docs/es/index.mdx
@@ -14,7 +14,7 @@ hero:
       <img src="/docs/images/hero-platform.svg" alt="F5 Distributed Cloud
       platform" />
 i18n:
-  sourceHash: 29a0827d18fb
+  sourceHash: d80f962a2933
   translator: machine
 ---
 

--- a/docs/fr/index.mdx
+++ b/docs/fr/index.mdx
@@ -14,7 +14,7 @@ hero:
       <img src="/docs/images/hero-platform.svg" alt="F5 Distributed Cloud
       platform" />
 i18n:
-  sourceHash: 29a0827d18fb
+  sourceHash: d80f962a2933
   translator: machine
 ---
 

--- a/docs/fr/index.mdx
+++ b/docs/fr/index.mdx
@@ -150,7 +150,7 @@ import LinkCard from '@f5-sales-demo/docs-theme/components/LinkCard.astro';
     icon="hashicorp-flight:terraform-color"
     title="Fournisseur Terraform"
     description="Fournisseur Terraform pour F5 Distributed Cloud."
-    href="https://f5-sales-demo.github.io/terraform-provider-f5xc/"
+    href="https://f5-sales-demo.github.io/terraform-provider-xcsh/"
   />
   <LinkCard
     icon="f5xc:data-intelligence"
@@ -208,7 +208,7 @@ import LinkCard from '@f5-sales-demo/docs-theme/components/LinkCard.astro';
     icon="f5xc:distributed-apps"
     title="Extension VS Code"
     description="Gérez les ressources F5 XC depuis VS Code avec IntelliSense et l'assistant de discussion xcsh."
-    href="https://f5-sales-demo.github.io/vscode-f5xc-tools/"
+    href="https://f5-sales-demo.github.io/vscode-xcsh/"
   />
   <LinkCard
     icon="f5xc:ai_assistant_logo"

--- a/docs/hi/index.mdx
+++ b/docs/hi/index.mdx
@@ -10,7 +10,7 @@ hero:
       <img src="/docs/images/hero-platform.svg" alt="F5 Distributed Cloud
       platform" />
 i18n:
-  sourceHash: 29a0827d18fb
+  sourceHash: d80f962a2933
   translator: machine
 ---
 

--- a/docs/hi/index.mdx
+++ b/docs/hi/index.mdx
@@ -146,7 +146,7 @@ import LinkCard from '@f5-sales-demo/docs-theme/components/LinkCard.astro';
     icon="hashicorp-flight:terraform-color"
     title="Terraform प्रोवाइडर"
     description="F5 Distributed Cloud के लिए Terraform प्रोवाइडर।"
-    href="https://f5-sales-demo.github.io/terraform-provider-f5xc/"
+    href="https://f5-sales-demo.github.io/terraform-provider-xcsh/"
   />
   <LinkCard
     icon="f5xc:data-intelligence"
@@ -204,7 +204,7 @@ import LinkCard from '@f5-sales-demo/docs-theme/components/LinkCard.astro';
     icon="f5xc:distributed-apps"
     title="VS Code एक्सटेंशन"
     description="IntelliSense और xcsh चैट असिस्टेंट के साथ VS Code से F5 XC संसाधन प्रबंधित करें।"
-    href="https://f5-sales-demo.github.io/vscode-f5xc-tools/"
+    href="https://f5-sales-demo.github.io/vscode-xcsh/"
   />
   <LinkCard
     icon="f5xc:ai_assistant_logo"

--- a/docs/it/index.mdx
+++ b/docs/it/index.mdx
@@ -10,7 +10,7 @@ hero:
       <img src="/docs/images/hero-platform.svg" alt="F5 Distributed Cloud
       platform" />
 i18n:
-  sourceHash: 29a0827d18fb
+  sourceHash: d80f962a2933
   translator: machine
 ---
 

--- a/docs/it/index.mdx
+++ b/docs/it/index.mdx
@@ -146,7 +146,7 @@ import LinkCard from '@f5-sales-demo/docs-theme/components/LinkCard.astro';
     icon="hashicorp-flight:terraform-color"
     title="Provider Terraform"
     description="Provider Terraform per F5 Distributed Cloud."
-    href="https://f5-sales-demo.github.io/terraform-provider-f5xc/"
+    href="https://f5-sales-demo.github.io/terraform-provider-xcsh/"
   />
   <LinkCard
     icon="f5xc:data-intelligence"
@@ -204,7 +204,7 @@ import LinkCard from '@f5-sales-demo/docs-theme/components/LinkCard.astro';
     icon="f5xc:distributed-apps"
     title="VS Code Estensione"
     description="Gestisci le risorse F5 XC da VS Code con IntelliSense e l'assistente di chat xcsh."
-    href="https://f5-sales-demo.github.io/vscode-f5xc-tools/"
+    href="https://f5-sales-demo.github.io/vscode-xcsh/"
   />
   <LinkCard
     icon="f5xc:ai_assistant_logo"

--- a/docs/ja/index.mdx
+++ b/docs/ja/index.mdx
@@ -10,7 +10,7 @@ hero:
       <img src="/docs/images/hero-platform.svg" alt="F5 Distributed Cloud
       platform" />
 i18n:
-  sourceHash: 29a0827d18fb
+  sourceHash: d80f962a2933
   translator: machine
 ---
 

--- a/docs/ja/index.mdx
+++ b/docs/ja/index.mdx
@@ -146,7 +146,7 @@ import LinkCard from '@f5-sales-demo/docs-theme/components/LinkCard.astro';
     icon="hashicorp-flight:terraform-color"
     title="Terraform プロバイダー"
     description="F5 Distributed Cloud 向け Terraform プロバイダー。"
-    href="https://f5-sales-demo.github.io/terraform-provider-f5xc/"
+    href="https://f5-sales-demo.github.io/terraform-provider-xcsh/"
   />
   <LinkCard
     icon="f5xc:data-intelligence"
@@ -204,7 +204,7 @@ import LinkCard from '@f5-sales-demo/docs-theme/components/LinkCard.astro';
     icon="f5xc:distributed-apps"
     title="VS Code 拡張機能"
     description="IntelliSense および xcsh チャットアシスタントを使用して VS Code から F5 XC リソースを管理する。"
-    href="https://f5-sales-demo.github.io/vscode-f5xc-tools/"
+    href="https://f5-sales-demo.github.io/vscode-xcsh/"
   />
   <LinkCard
     icon="f5xc:ai_assistant_logo"

--- a/docs/ko/index.mdx
+++ b/docs/ko/index.mdx
@@ -10,7 +10,7 @@ hero:
       <img src="/docs/images/hero-platform.svg" alt="F5 Distributed Cloud
       platform" />
 i18n:
-  sourceHash: 29a0827d18fb
+  sourceHash: d80f962a2933
   translator: machine
 ---
 

--- a/docs/ko/index.mdx
+++ b/docs/ko/index.mdx
@@ -146,7 +146,7 @@ import LinkCard from '@f5-sales-demo/docs-theme/components/LinkCard.astro';
     icon="hashicorp-flight:terraform-color"
     title="Terraform 프로바이더"
     description="F5 Distributed Cloud용 Terraform 프로바이더."
-    href="https://f5-sales-demo.github.io/terraform-provider-f5xc/"
+    href="https://f5-sales-demo.github.io/terraform-provider-xcsh/"
   />
   <LinkCard
     icon="f5xc:data-intelligence"
@@ -204,7 +204,7 @@ import LinkCard from '@f5-sales-demo/docs-theme/components/LinkCard.astro';
     icon="f5xc:distributed-apps"
     title="VS Code 확장"
     description="IntelliSense 및 xcsh 채팅 어시스턴트를 통해 VS Code에서 F5 XC 리소스를 관리합니다."
-    href="https://f5-sales-demo.github.io/vscode-f5xc-tools/"
+    href="https://f5-sales-demo.github.io/vscode-xcsh/"
   />
   <LinkCard
     icon="f5xc:ai_assistant_logo"

--- a/docs/llms-federated-sites.json
+++ b/docs/llms-federated-sites.json
@@ -115,7 +115,7 @@
   },
   {
     "label": "Terraform Provider",
-    "url": "https://f5-sales-demo.github.io/terraform-provider-f5xc/llms.txt",
+    "url": "https://f5-sales-demo.github.io/terraform-provider-xcsh/llms.txt",
     "description": "Terraform provider for F5 Distributed Cloud",
     "category": "developer-tools"
   },
@@ -139,7 +139,7 @@
   },
   {
     "label": "VS Code Extension",
-    "url": "https://f5-sales-demo.github.io/vscode-f5xc-tools/llms.txt",
+    "url": "https://f5-sales-demo.github.io/vscode-xcsh/llms.txt",
     "description": "VS Code extension for managing F5 Distributed Cloud resources",
     "category": "developer-tools"
   },

--- a/docs/pt-br/index.mdx
+++ b/docs/pt-br/index.mdx
@@ -150,7 +150,7 @@ import LinkCard from '@f5-sales-demo/docs-theme/components/LinkCard.astro';
     icon="hashicorp-flight:terraform-color"
     title="Provedor Terraform"
     description="Provedor Terraform para F5 Distributed Cloud."
-    href="https://f5-sales-demo.github.io/terraform-provider-f5xc/"
+    href="https://f5-sales-demo.github.io/terraform-provider-xcsh/"
   />
   <LinkCard
     icon="f5xc:data-intelligence"
@@ -208,7 +208,7 @@ import LinkCard from '@f5-sales-demo/docs-theme/components/LinkCard.astro';
     icon="f5xc:distributed-apps"
     title="Extensão VS Code"
     description="Gerencie recursos F5 XC a partir do VS Code com IntelliSense e assistente de chat xcsh."
-    href="https://f5-sales-demo.github.io/vscode-f5xc-tools/"
+    href="https://f5-sales-demo.github.io/vscode-xcsh/"
   />
   <LinkCard
     icon="f5xc:ai_assistant_logo"

--- a/docs/pt-br/index.mdx
+++ b/docs/pt-br/index.mdx
@@ -14,7 +14,7 @@ hero:
       <img src="/docs/images/hero-platform.svg" alt="F5 Distributed Cloud
       platform" />
 i18n:
-  sourceHash: 29a0827d18fb
+  sourceHash: d80f962a2933
   translator: machine
 ---
 

--- a/docs/th/index.mdx
+++ b/docs/th/index.mdx
@@ -146,7 +146,7 @@ import LinkCard from '@f5-sales-demo/docs-theme/components/LinkCard.astro';
     icon="hashicorp-flight:terraform-color"
     title="Terraform Provider"
     description="Terraform Provider สำหรับ F5 Distributed Cloud"
-    href="https://f5-sales-demo.github.io/terraform-provider-f5xc/"
+    href="https://f5-sales-demo.github.io/terraform-provider-xcsh/"
   />
   <LinkCard
     icon="f5xc:data-intelligence"
@@ -204,7 +204,7 @@ import LinkCard from '@f5-sales-demo/docs-theme/components/LinkCard.astro';
     icon="f5xc:distributed-apps"
     title="VS Code ส่วนขยาย"
     description="จัดการทรัพยากร F5 XC จาก VS Code ด้วย IntelliSense และผู้ช่วยแชท xcsh"
-    href="https://f5-sales-demo.github.io/vscode-f5xc-tools/"
+    href="https://f5-sales-demo.github.io/vscode-xcsh/"
   />
   <LinkCard
     icon="f5xc:ai_assistant_logo"

--- a/docs/th/index.mdx
+++ b/docs/th/index.mdx
@@ -10,7 +10,7 @@ hero:
       <img src="/docs/images/hero-platform.svg" alt="F5 Distributed Cloud
       platform" />
 i18n:
-  sourceHash: 29a0827d18fb
+  sourceHash: d80f962a2933
   translator: machine
 ---
 

--- a/docs/zh-cn/index.mdx
+++ b/docs/zh-cn/index.mdx
@@ -10,7 +10,7 @@ hero:
       <img src="/docs/images/hero-platform.svg" alt="F5 Distributed Cloud
       platform" />
 i18n:
-  sourceHash: 29a0827d18fb
+  sourceHash: d80f962a2933
   translator: machine
 ---
 

--- a/docs/zh-cn/index.mdx
+++ b/docs/zh-cn/index.mdx
@@ -146,7 +146,7 @@ import LinkCard from '@f5-sales-demo/docs-theme/components/LinkCard.astro';
     icon="hashicorp-flight:terraform-color"
     title="Terraform Provider"
     description="适用于 F5 分布式云的 Terraform Provider。"
-    href="https://f5-sales-demo.github.io/terraform-provider-f5xc/"
+    href="https://f5-sales-demo.github.io/terraform-provider-xcsh/"
   />
   <LinkCard
     icon="f5xc:data-intelligence"
@@ -204,7 +204,7 @@ import LinkCard from '@f5-sales-demo/docs-theme/components/LinkCard.astro';
     icon="f5xc:distributed-apps"
     title="VS Code 扩展"
     description="通过 IntelliSense 和 xcsh 聊天助手在 VS Code 中管理 F5 XC 资源。"
-    href="https://f5-sales-demo.github.io/vscode-f5xc-tools/"
+    href="https://f5-sales-demo.github.io/vscode-xcsh/"
   />
   <LinkCard
     icon="f5xc:ai_assistant_logo"

--- a/docs/zh-tw/index.mdx
+++ b/docs/zh-tw/index.mdx
@@ -10,7 +10,7 @@ hero:
       <img src="/docs/images/hero-platform.svg" alt="F5 Distributed Cloud
       platform" />
 i18n:
-  sourceHash: 29a0827d18fb
+  sourceHash: d80f962a2933
   translator: machine
 ---
 

--- a/docs/zh-tw/index.mdx
+++ b/docs/zh-tw/index.mdx
@@ -146,7 +146,7 @@ import LinkCard from '@f5-sales-demo/docs-theme/components/LinkCard.astro';
     icon="hashicorp-flight:terraform-color"
     title="Terraform 提供者"
     description="適用於 F5 Distributed Cloud 的 Terraform 提供者。"
-    href="https://f5-sales-demo.github.io/terraform-provider-f5xc/"
+    href="https://f5-sales-demo.github.io/terraform-provider-xcsh/"
   />
   <LinkCard
     icon="f5xc:data-intelligence"
@@ -204,7 +204,7 @@ import LinkCard from '@f5-sales-demo/docs-theme/components/LinkCard.astro';
     icon="f5xc:distributed-apps"
     title="VS Code 擴充功能"
     description="透過 IntelliSense 與 xcsh 聊天助理，從 VS Code 管理 F5 XC 資源。"
-    href="https://f5-sales-demo.github.io/vscode-f5xc-tools/"
+    href="https://f5-sales-demo.github.io/vscode-xcsh/"
   />
   <LinkCard
     icon="f5xc:ai_assistant_logo"


### PR DESCRIPTION
## Summary

Landing-page `LinkCard` hrefs and `llms-federated-sites.json` linked to two **pre-rename** repos that now 404:

| Was (404) | Now (200) |
|---|---|
| `vscode-f5xc-tools` | `vscode-xcsh` |
| `terraform-provider-f5xc` | `terraform-provider-xcsh` |

Exact-substring replacement across all 13 locale `index.mdx` files and `llms-federated-sites.json`. No other `f5xc` naming touched.

## Verification

- `grep -rn 'vscode-f5xc-tools\|terraform-provider-f5xc' .` → **0**
- `llms-federated-sites.json` parses as valid JSON.
- Live: old URLs 404; `vscode-xcsh` / `terraform-provider-xcsh` return 200.

Fixes #680