### PR TITLE
chore: sync managed files from governance template

### DIFF
--- a/.claude/governance.json
+++ b/.claude/governance.json
@@ -61,6 +61,8 @@
     ".python-lint",
     ".mypy.ini",
     "scripts/locale-lint.sh",
+    "scripts/check-repo-hygiene.sh",
+    "tests/test-check-repo-hygiene.sh",
     "trivy.yaml",
     ".claude/settings.json",
     ".claude/governance.json",

--- a/.gitignore
+++ b/.gitignore
@@ -203,3 +203,7 @@ pi-*.html
 packages/coding-agent/src/internal-urls/docs-index.generated.ts
 packages/coding-agent/src/internal-urls/build-info.generated.ts
 packages/typescript-edit-benchmark/runs/
+
+# Verified-review working artifacts (findings and verification evidence).
+# No trailing slash, so a symlink of this name is matched too.
+.codex-review

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,6 +39,23 @@ repos:
         pass_filenames: false
 
   # ===========================================================================
+  # Repository hygiene — rejects tracked symlinks with absolute targets and
+  # hardcoded home directories. A `.gitignore` pattern ending in `/` matches
+  # only directories, so a symlink of an ignored name is still staged.
+  # ===========================================================================
+  - repo: local
+    hooks:
+      - id: check-repo-hygiene
+        name: Repository hygiene
+        entry: >-
+          bash -c
+          'if [ -f scripts/check-repo-hygiene.sh ];
+          then bash scripts/check-repo-hygiene.sh; fi'
+        language: system
+        always_run: true
+        pass_filenames: false
+
+  # ===========================================================================
   # File size guard
   # ===========================================================================
   - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -218,6 +235,7 @@ ci:
   # They run locally and in GitHub Actions CI where tools are pre-installed.
   skip:
     - local-hooks
+    - check-repo-hygiene
     - yamllint
     - markdownlint
     - shellcheck


### PR DESCRIPTION
Closes #730

Synced managed files from `f5-sales-demo/docs-control` canonical source:

- .gitignore
- .pre-commit-config.yaml
- .claude/governance.json