### PR TITLE
docs: add xcsh Action to portal

### DIFF
--- a/docs/ar/index.mdx
+++ b/docs/ar/index.mdx
@@ -10,7 +10,7 @@ hero:
       <img src="/docs/images/hero-platform.svg" alt="F5 Distributed Cloud
       platform" />
 i18n:
-  sourceHash: d80f962a2933
+  sourceHash: 4e37b6c9e4cf
   translator: machine
 ---
 
@@ -147,6 +147,12 @@ import LinkCard from '@f5-sales-demo/docs-theme/components/LinkCard.astro';
     title="موفر Terraform"
     description="موفر Terraform لـ F5 Distributed Cloud."
     href="https://f5-sales-demo.github.io/terraform-provider-xcsh/"
+  />
+  <LinkCard
+    icon="f5xc:ai_assistant_logo"
+    title="xcsh GitHub Action"
+    description="طبّق ملفات بيان F5 Distributed Cloud في GitHub Actions دون استدعاء نموذج لغوي كبير."
+    href="https://f5-sales-demo.github.io/xcsh-action/"
   />
   <LinkCard
     icon="f5xc:data-intelligence"

--- a/docs/de/index.mdx
+++ b/docs/de/index.mdx
@@ -10,7 +10,7 @@ hero:
       <img src="/docs/images/hero-platform.svg" alt="F5 Distributed Cloud
       platform" />
 i18n:
-  sourceHash: d80f962a2933
+  sourceHash: 4e37b6c9e4cf
   translator: machine
 ---
 
@@ -147,6 +147,12 @@ import LinkCard from '@f5-sales-demo/docs-theme/components/LinkCard.astro';
     title="Terraform-Provider"
     description="Terraform-Provider für F5 Distributed Cloud."
     href="https://f5-sales-demo.github.io/terraform-provider-xcsh/"
+  />
+  <LinkCard
+    icon="f5xc:ai_assistant_logo"
+    title="xcsh GitHub Action"
+    description="F5-Distributed-Cloud-Manifeste in GitHub Actions ohne LLM-Aufruf anwenden."
+    href="https://f5-sales-demo.github.io/xcsh-action/"
   />
   <LinkCard
     icon="f5xc:data-intelligence"

--- a/docs/en/index.mdx
+++ b/docs/en/index.mdx
@@ -144,6 +144,12 @@ import LinkCard from '@f5-sales-demo/docs-theme/components/LinkCard.astro';
     href="https://f5-sales-demo.github.io/terraform-provider-xcsh/"
   />
   <LinkCard
+    icon="f5xc:ai_assistant_logo"
+    title="xcsh GitHub Action"
+    description="Apply F5 Distributed Cloud manifests in GitHub Actions without an LLM turn."
+    href="https://f5-sales-demo.github.io/xcsh-action/"
+  />
+  <LinkCard
     icon="f5xc:data-intelligence"
     title="API Specs"
     description="OpenAPI spec validation and reconciliation for F5 Distributed Cloud."

--- a/docs/es/index.mdx
+++ b/docs/es/index.mdx
@@ -14,7 +14,7 @@ hero:
       <img src="/docs/images/hero-platform.svg" alt="F5 Distributed Cloud
       platform" />
 i18n:
-  sourceHash: d80f962a2933
+  sourceHash: 4e37b6c9e4cf
   translator: machine
 ---
 
@@ -151,6 +151,12 @@ import LinkCard from '@f5-sales-demo/docs-theme/components/LinkCard.astro';
     title="Proveedor de Terraform"
     description="Proveedor de Terraform para F5 Distributed Cloud."
     href="https://f5-sales-demo.github.io/terraform-provider-xcsh/"
+  />
+  <LinkCard
+    icon="f5xc:ai_assistant_logo"
+    title="xcsh GitHub Action"
+    description="Aplica manifiestos de F5 Distributed Cloud en GitHub Actions sin invocar un LLM."
+    href="https://f5-sales-demo.github.io/xcsh-action/"
   />
   <LinkCard
     icon="f5xc:data-intelligence"

--- a/docs/fr/index.mdx
+++ b/docs/fr/index.mdx
@@ -14,7 +14,7 @@ hero:
       <img src="/docs/images/hero-platform.svg" alt="F5 Distributed Cloud
       platform" />
 i18n:
-  sourceHash: d80f962a2933
+  sourceHash: 4e37b6c9e4cf
   translator: machine
 ---
 
@@ -151,6 +151,12 @@ import LinkCard from '@f5-sales-demo/docs-theme/components/LinkCard.astro';
     title="Fournisseur Terraform"
     description="Fournisseur Terraform pour F5 Distributed Cloud."
     href="https://f5-sales-demo.github.io/terraform-provider-xcsh/"
+  />
+  <LinkCard
+    icon="f5xc:ai_assistant_logo"
+    title="xcsh GitHub Action"
+    description="Appliquez des manifestes F5 Distributed Cloud dans GitHub Actions sans appel à un LLM."
+    href="https://f5-sales-demo.github.io/xcsh-action/"
   />
   <LinkCard
     icon="f5xc:data-intelligence"

--- a/docs/hi/index.mdx
+++ b/docs/hi/index.mdx
@@ -10,7 +10,7 @@ hero:
       <img src="/docs/images/hero-platform.svg" alt="F5 Distributed Cloud
       platform" />
 i18n:
-  sourceHash: d80f962a2933
+  sourceHash: 4e37b6c9e4cf
   translator: machine
 ---
 
@@ -147,6 +147,12 @@ import LinkCard from '@f5-sales-demo/docs-theme/components/LinkCard.astro';
     title="Terraform प्रोवाइडर"
     description="F5 Distributed Cloud के लिए Terraform प्रोवाइडर।"
     href="https://f5-sales-demo.github.io/terraform-provider-xcsh/"
+  />
+  <LinkCard
+    icon="f5xc:ai_assistant_logo"
+    title="xcsh GitHub Action"
+    description="बिना LLM कॉल के GitHub Actions में F5 Distributed Cloud मैनिफ़ेस्ट लागू करें।"
+    href="https://f5-sales-demo.github.io/xcsh-action/"
   />
   <LinkCard
     icon="f5xc:data-intelligence"

--- a/docs/it/index.mdx
+++ b/docs/it/index.mdx
@@ -10,7 +10,7 @@ hero:
       <img src="/docs/images/hero-platform.svg" alt="F5 Distributed Cloud
       platform" />
 i18n:
-  sourceHash: d80f962a2933
+  sourceHash: 4e37b6c9e4cf
   translator: machine
 ---
 
@@ -147,6 +147,12 @@ import LinkCard from '@f5-sales-demo/docs-theme/components/LinkCard.astro';
     title="Provider Terraform"
     description="Provider Terraform per F5 Distributed Cloud."
     href="https://f5-sales-demo.github.io/terraform-provider-xcsh/"
+  />
+  <LinkCard
+    icon="f5xc:ai_assistant_logo"
+    title="xcsh GitHub Action"
+    description="Applica i manifest F5 Distributed Cloud in GitHub Actions senza invocare un LLM."
+    href="https://f5-sales-demo.github.io/xcsh-action/"
   />
   <LinkCard
     icon="f5xc:data-intelligence"

--- a/docs/ja/index.mdx
+++ b/docs/ja/index.mdx
@@ -10,7 +10,7 @@ hero:
       <img src="/docs/images/hero-platform.svg" alt="F5 Distributed Cloud
       platform" />
 i18n:
-  sourceHash: d80f962a2933
+  sourceHash: 4e37b6c9e4cf
   translator: machine
 ---
 
@@ -147,6 +147,12 @@ import LinkCard from '@f5-sales-demo/docs-theme/components/LinkCard.astro';
     title="Terraform プロバイダー"
     description="F5 Distributed Cloud 向け Terraform プロバイダー。"
     href="https://f5-sales-demo.github.io/terraform-provider-xcsh/"
+  />
+  <LinkCard
+    icon="f5xc:ai_assistant_logo"
+    title="xcsh GitHub Action"
+    description="LLM を呼び出さずに GitHub Actions で F5 Distributed Cloud マニフェストを適用します。"
+    href="https://f5-sales-demo.github.io/xcsh-action/"
   />
   <LinkCard
     icon="f5xc:data-intelligence"

--- a/docs/ko/index.mdx
+++ b/docs/ko/index.mdx
@@ -10,7 +10,7 @@ hero:
       <img src="/docs/images/hero-platform.svg" alt="F5 Distributed Cloud
       platform" />
 i18n:
-  sourceHash: d80f962a2933
+  sourceHash: 4e37b6c9e4cf
   translator: machine
 ---
 
@@ -147,6 +147,12 @@ import LinkCard from '@f5-sales-demo/docs-theme/components/LinkCard.astro';
     title="Terraform 프로바이더"
     description="F5 Distributed Cloud용 Terraform 프로바이더."
     href="https://f5-sales-demo.github.io/terraform-provider-xcsh/"
+  />
+  <LinkCard
+    icon="f5xc:ai_assistant_logo"
+    title="xcsh GitHub Action"
+    description="LLM 호출 없이 GitHub Actions에서 F5 Distributed Cloud 매니페스트를 적용합니다."
+    href="https://f5-sales-demo.github.io/xcsh-action/"
   />
   <LinkCard
     icon="f5xc:data-intelligence"

--- a/docs/llms-federated-sites.json
+++ b/docs/llms-federated-sites.json
@@ -120,6 +120,12 @@
     "category": "developer-tools"
   },
   {
+    "label": "xcsh Action",
+    "url": "https://f5-sales-demo.github.io/xcsh-action/llms.txt",
+    "description": "Deterministic F5 Distributed Cloud manifest operations for GitHub Actions",
+    "category": "developer-tools"
+  },
+  {
     "label": "Dev Container",
     "url": "https://f5-sales-demo.github.io/devcontainer/llms.txt",
     "description": "Isolated development environment with AI coding tools",

--- a/docs/pt-br/index.mdx
+++ b/docs/pt-br/index.mdx
@@ -14,7 +14,7 @@ hero:
       <img src="/docs/images/hero-platform.svg" alt="F5 Distributed Cloud
       platform" />
 i18n:
-  sourceHash: d80f962a2933
+  sourceHash: 4e37b6c9e4cf
   translator: machine
 ---
 
@@ -151,6 +151,12 @@ import LinkCard from '@f5-sales-demo/docs-theme/components/LinkCard.astro';
     title="Provedor Terraform"
     description="Provedor Terraform para F5 Distributed Cloud."
     href="https://f5-sales-demo.github.io/terraform-provider-xcsh/"
+  />
+  <LinkCard
+    icon="f5xc:ai_assistant_logo"
+    title="xcsh GitHub Action"
+    description="Aplique manifestos do F5 Distributed Cloud no GitHub Actions sem invocar um LLM."
+    href="https://f5-sales-demo.github.io/xcsh-action/"
   />
   <LinkCard
     icon="f5xc:data-intelligence"

--- a/docs/th/index.mdx
+++ b/docs/th/index.mdx
@@ -10,7 +10,7 @@ hero:
       <img src="/docs/images/hero-platform.svg" alt="F5 Distributed Cloud
       platform" />
 i18n:
-  sourceHash: d80f962a2933
+  sourceHash: 4e37b6c9e4cf
   translator: machine
 ---
 
@@ -147,6 +147,12 @@ import LinkCard from '@f5-sales-demo/docs-theme/components/LinkCard.astro';
     title="Terraform Provider"
     description="Terraform Provider สำหรับ F5 Distributed Cloud"
     href="https://f5-sales-demo.github.io/terraform-provider-xcsh/"
+  />
+  <LinkCard
+    icon="f5xc:ai_assistant_logo"
+    title="xcsh GitHub Action"
+    description="ใช้ Manifest ของ F5 Distributed Cloud ใน GitHub Actions โดยไม่เรียกใช้ LLM"
+    href="https://f5-sales-demo.github.io/xcsh-action/"
   />
   <LinkCard
     icon="f5xc:data-intelligence"

--- a/docs/zh-cn/index.mdx
+++ b/docs/zh-cn/index.mdx
@@ -10,7 +10,7 @@ hero:
       <img src="/docs/images/hero-platform.svg" alt="F5 Distributed Cloud
       platform" />
 i18n:
-  sourceHash: d80f962a2933
+  sourceHash: 4e37b6c9e4cf
   translator: machine
 ---
 
@@ -147,6 +147,12 @@ import LinkCard from '@f5-sales-demo/docs-theme/components/LinkCard.astro';
     title="Terraform Provider"
     description="适用于 F5 分布式云的 Terraform Provider。"
     href="https://f5-sales-demo.github.io/terraform-provider-xcsh/"
+  />
+  <LinkCard
+    icon="f5xc:ai_assistant_logo"
+    title="xcsh GitHub Action"
+    description="无需调用 LLM，即可在 GitHub Actions 中应用 F5 Distributed Cloud 清单。"
+    href="https://f5-sales-demo.github.io/xcsh-action/"
   />
   <LinkCard
     icon="f5xc:data-intelligence"

--- a/docs/zh-tw/index.mdx
+++ b/docs/zh-tw/index.mdx
@@ -10,7 +10,7 @@ hero:
       <img src="/docs/images/hero-platform.svg" alt="F5 Distributed Cloud
       platform" />
 i18n:
-  sourceHash: d80f962a2933
+  sourceHash: 4e37b6c9e4cf
   translator: machine
 ---
 
@@ -147,6 +147,12 @@ import LinkCard from '@f5-sales-demo/docs-theme/components/LinkCard.astro';
     title="Terraform 提供者"
     description="適用於 F5 Distributed Cloud 的 Terraform 提供者。"
     href="https://f5-sales-demo.github.io/terraform-provider-xcsh/"
+  />
+  <LinkCard
+    icon="f5xc:ai_assistant_logo"
+    title="xcsh GitHub Action"
+    description="無需呼叫 LLM，即可在 GitHub Actions 中套用 F5 Distributed Cloud 資訊清單。"
+    href="https://f5-sales-demo.github.io/xcsh-action/"
   />
   <LinkCard
     icon="f5xc:data-intelligence"


### PR DESCRIPTION
## Summary

- add the xcsh GitHub Action to every localized Automation section
- register the Action documentation site in the federated developer-tool inventory
- refresh translation source hashes while preserving identical card/link structure

## Verification

- `bash scripts/antigravity-translate-staged.sh`
- `bash scripts/check-pii.sh --scope staged --mode enforce`
- `bash scripts/check-repo-hygiene.sh`
- `bash scripts/locale-lint.sh`
- `bash scripts/lint-mdx-prose.sh docs/en/index.mdx`
- all three repository shell test suites (via the required local Antigravity review)
- local Antigravity branch review: no findings

Closes #843

Depends on f5-sales-demo/xcsh-action#1.