### PR TITLE
fix(llms): clarify xcsh GitHub Action federation

### DIFF
--- a/docs/llms-federated-site-categories.json
+++ b/docs/llms-federated-site-categories.json
@@ -17,7 +17,7 @@
   {
     "id": "developer-tools",
     "label": "Developer Tools",
-    "description": "SDKs, providers, and agentic tooling."
+    "description": "CLIs, SDKs, providers, GitHub Actions, CI/CD automation, extensions, and agentic tooling."
   },
   {
     "id": "build-platform",

--- a/docs/llms-federated-sites.json
+++ b/docs/llms-federated-sites.json
@@ -120,9 +120,9 @@
     "category": "developer-tools"
   },
   {
-    "label": "xcsh Action",
+    "label": "xcsh GitHub Action",
     "url": "https://f5-sales-demo.github.io/xcsh-action/llms.txt",
-    "description": "Deterministic F5 Distributed Cloud manifest operations for GitHub Actions",
+    "description": "GitHub Marketplace Action for deterministic F5 Distributed Cloud manifest operations",
     "category": "developer-tools"
   },
   {


### PR DESCRIPTION
## What

- identify xcsh-action explicitly as the xcsh GitHub Action and GitHub Marketplace Action
- describe Developer Tools as covering GitHub Actions and CI/CD automation

## Why

This makes the federated llms.txt index route workflow and pipeline requests to the published xcsh-action documentation.

Closes #885

## Testing

- `jq` JSON and federation invariant validation
- `pre-commit run --files docs/llms-federated-sites.json docs/llms-federated-site-categories.json`
- all repository `tests/test-*.sh` suites
- exact-HEAD Antigravity review
